### PR TITLE
Eapis Namespaces

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,14 +40,14 @@ build_script:
   #
   # Download Repos
   #
-  - git clone -b dev https://github.com/Bareflank/hypervisor.git hypervisor
+  - git clone -b no-namespace https://github.com/connojd/hypervisor.git hypervisor
 
   #
   # Visual Studio (MSBuild / Static Libraries)
   #
   - mkdir hypervisor\build
   - cd hypervisor\build
-  - cmake -G "Visual Studio 15 2017 Win64" -DEXTENSIONS="C:/projects/extended-apis/CMakeLists.txt" -DBFM_VMM="eapis_vmm_static" -DENABLE_TESTS_ONLY=ON ..
+  - cmake -G "Visual Studio 15 2017 Win64" -DEXTENSIONS="C:/projects/extended-apis/CMakeLists.txt" -DENABLE_BUILD_VMM=OFF -DENABLE_BUILD_USERSPACE=OFF -DENABLE_BUILD_TEST=ON ..
   - msbuild /m:3 hypervisor.sln
   - cmake --build . --target test
   - cd ..
@@ -57,6 +57,6 @@ build_script:
   #
   - set PATH=%BFPATH%;%APPVEYOR_BUILD_FOLDER%/hypervisor/build_cygwin/bfprefix/bin
   - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; mkdir hypervisor/build_cygwin"'
-  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER/hypervisor/build_cygwin; cmake -DEXTENSIONS="C:/projects/extended-apis/CMakeLists.txt" -DBFM_VMM="eapis_vmm_static" -DENABLE_TESTS_ONLY=ON .."'
+  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER/hypervisor/build_cygwin; cmake -DEXTENSIONS="C:/projects/extended-apis/CMakeLists.txt" -DENABLE_BUILD_TEST=ON .."'
   - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER/hypervisor/build_cygwin; make -j3"'
   - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER/hypervisor/build_cygwin; make unittest"'

--- a/include/hve/arch/intel_x64/exit_handler/cpuid_verifiers.h
+++ b/include/hve/arch/intel_x64/exit_handler/cpuid_verifiers.h
@@ -25,6 +25,8 @@
 #include "../../../../hve/arch/intel_x64/exit_handler/exit_handler.h"
 #include "../../../../hve/arch/intel_x64/exit_handler/verifiers.h"
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 /// @cond
 
 // -----------------------------------------------------------------------------
@@ -89,8 +91,8 @@ public:
     }
 
     virtual verifier_result verify(
-        exit_handler_intel_x64_eapis::cpuid_type leaf,
-        exit_handler_intel_x64_eapis::cpuid_type subleaf,
+        exit_handler_eapis::exit_handler::cpuid_type leaf,
+        exit_handler_eapis::exit_handler::cpuid_type subleaf,
         std::string eax, std::string ebx, std::string ecx, std::string edx)
     {
         bfignored(leaf);
@@ -112,8 +114,8 @@ public:
     default_verifier__reset_cpuid_leaf() = default;
     ~default_verifier__reset_cpuid_leaf() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::cpuid_type leaf,
-                                   exit_handler_intel_x64_eapis::cpuid_type subleaf)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::cpuid_type leaf,
+                                   exit_handler_eapis::exit_handler::cpuid_type subleaf)
     { bfignored(leaf); bfignored(subleaf); return default_verify(); }
 };
 

--- a/include/hve/arch/intel_x64/exit_handler/exit_handler.h
+++ b/include/hve/arch/intel_x64/exit_handler/exit_handler.h
@@ -36,6 +36,8 @@
 #include <bfvmm/memory_manager/object_allocator.h>
 #include <bfvmm/hve/arch/intel_x64/exit_handler/exit_handler.h>
 
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
+
 // -----------------------------------------------------------------------------
 // Exports
 // -----------------------------------------------------------------------------
@@ -67,34 +69,42 @@
 /// subclassed, and certain functions need to be handled based on how the
 /// VMCS is setup.
 ///
-class EXPORT_EAPIS_HVE exit_handler_intel_x64_eapis :
-    public exit_handler_intel_x64
+namespace eapis
+{
+namespace hve
+{
+namespace intel_x64
+{
+namespace exit_handler
+{
+
+class EXPORT_EAPIS_HVE exit_handler : public bfvmm::intel_x64::exit_handler
 {
 public:
 
     using count_type = uint64_t;                                                        ///< Count type used for logging
-    using port_type = x64::portio::port_addr_type;                                      ///< Port type
+    using port_type = ::x64::portio::port_addr_type;                                      ///< Port type
     using port_list_type = std::vector<port_type>;                                      ///< Port list type
-    using port_log_type = std::map<intel_x64::vmcs::value_type, count_type>;            ///< Port log type
+    using port_log_type = std::map<::intel_x64::vmcs::value_type, count_type>;            ///< Port log type
     using denial_list_type = std::vector<std::string>;                                  ///< Denial list type
     using policy_type = std::map<vp::index_type, std::unique_ptr<vmcall_verifier>>;     ///< VMCall policy type
-    using msr_type = x64::msrs::field_type;                                             ///< MSR type
+    using msr_type = ::x64::msrs::field_type;                                             ///< MSR type
     using msr_list_type = std::vector<msr_type>;                                        ///< MSR list type
     using msr_log_type = std::map<msr_type, count_type>;                                ///< MSR log type
-    using gpr_index_type = intel_x64::vmcs::value_type;                                 ///< General purpose register index type
+    using gpr_index_type = ::intel_x64::vmcs::value_type;                                 ///< General purpose register index type
     using gpr_value_type = uintptr_t;                                                   ///< General purpose register value type
-    using cr0_value_type = intel_x64::cr0::value_type;                                  ///< CR0 value type
-    using cr3_value_type = intel_x64::cr3::value_type;                                  ///< CR3 value type
-    using cr4_value_type = intel_x64::cr4::value_type;                                  ///< CR4 value type
-    using cr8_value_type = intel_x64::cr8::value_type;                                  ///< CR8 value type
-    using vector_type = intel_x64::vmcs::value_type;                                    ///< Event vector type
-    using event_type = intel_x64::vmcs::value_type;                                     ///< Event type
-    using error_code_type = intel_x64::vmcs::value_type;                                ///< Event error code type
-    using instr_len_type = intel_x64::vmcs::value_type;                                 ///< Event instruction length type
-    using tpr_shadow_type = intel_x64::cr8::value_type;                                 ///< TPR shadow type
-    using cpuid_type = x64::cpuid::field_type;                                          ///< CPUID type
+    using cr0_value_type = ::intel_x64::cr0::value_type;                                  ///< CR0 value type
+    using cr3_value_type = ::intel_x64::cr3::value_type;                                  ///< CR3 value type
+    using cr4_value_type = ::intel_x64::cr4::value_type;                                  ///< CR4 value type
+    using cr8_value_type = ::intel_x64::cr8::value_type;                                  ///< CR8 value type
+    using vector_type = ::intel_x64::vmcs::value_type;                                    ///< Event vector type
+    using event_type = ::intel_x64::vmcs::value_type;                                     ///< Event type
+    using error_code_type = ::intel_x64::vmcs::value_type;                                ///< Event error code type
+    using instr_len_type = ::intel_x64::vmcs::value_type;                                 ///< Event instruction length type
+    using tpr_shadow_type = ::intel_x64::cr8::value_type;                                 ///< TPR shadow type
+    using cpuid_type = ::x64::cpuid::field_type;                                          ///< CPUID type
     using cpuid_key_type = uint64_t;                                                    ///< CPUID key type
-    using cpuid_regs_type = x64::cpuid::cpuid_regs;                                     ///< CPUID regs type
+    using cpuid_regs_type = ::x64::cpuid::cpuid_regs;                                     ///< CPUID regs type
     using cpuid_emu_map_type = std::map<cpuid_key_type, cpuid_regs_type>;               ///< CPUID emu map type
     using cpuid_log_type = std::map<cpuid_key_type, count_type>;                        ///< CPUID log type
 
@@ -102,7 +112,7 @@ public:
     ///
     /// Defines the function signature for a monitor callback function.
     ///
-    using monitor_trap_callback = void(exit_handler_intel_x64_eapis::*)();
+    using monitor_trap_callback = void(exit_handler::*)();
 
     /// @struct event
     ///
@@ -134,14 +144,14 @@ public:
     /// @expects
     /// @ensures
     ///
-    exit_handler_intel_x64_eapis();
+    exit_handler();
 
     /// Destructor
     ///
     /// @expects
     /// @ensures
     ///
-    ~exit_handler_intel_x64_eapis() override = default;
+    ~exit_handler() override = default;
 
     /// Inject Event
     ///
@@ -179,7 +189,7 @@ protected:
     /// Example:
     /// @code
     ///
-    /// class my_exit_handler : public exit_handler_intel_x64_eapis
+    /// class my_exit_handler : public exit_handler
     /// {
     /// public:
     ///     void monitor_trap_callback()
@@ -198,7 +208,7 @@ protected:
     template<typename T, typename = std::enable_if<std::is_member_function_pointer<T>::value>>
     void register_monitor_trap(T callback)
     {
-        intel_x64::vmcs::primary_processor_based_vm_execution_controls::monitor_trap_flag::enable();
+        ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::monitor_trap_flag::enable();
         m_monitor_trap_callback = static_cast<monitor_trap_callback>(callback);
     }
 
@@ -275,7 +285,7 @@ protected:
 
     /// @cond
 
-    void handle_exit(intel_x64::vmcs::value_type reason) override;
+    void handle_exit(::intel_x64::vmcs::value_type reason) override;
 
     virtual void handle_exit__monitor_trap_flag();
     virtual void handle_exit__io_instruction();
@@ -554,7 +564,7 @@ private:
 
     void unhandled_monitor_trap_callback();
     monitor_trap_callback m_monitor_trap_callback{
-        &exit_handler_intel_x64_eapis::unhandled_monitor_trap_callback};
+        &exit_handler::unhandled_monitor_trap_callback};
 
 #ifndef ENABLE_UNITTESTING
 private:
@@ -615,28 +625,33 @@ public:
     /// @cond
 
     void
-    set_vmcs(gsl::not_null<vmcs_intel_x64 *> vmcs) override
+    set_vmcs(gsl::not_null<bfvmm::intel_x64::vmcs *> vmcs) override
     {
         m_vmcs = vmcs;
-        m_vmcs_eapis = dynamic_cast<vmcs_intel_x64_eapis *>(m_vmcs);
+        m_vmcs_eapis = dynamic_cast<vmcs_eapis::vmcs *>(m_vmcs);
     }
 
     /// @endcond
 
-    vmcs_intel_x64_eapis *m_vmcs_eapis{nullptr};    ///< Pointer to the EAPIS vmcs
+    vmcs_eapis::vmcs *m_vmcs_eapis{nullptr};    ///< Pointer to the EAPIS vmcs
 
 public:
 
     /// @cond
 
-    exit_handler_intel_x64_eapis(exit_handler_intel_x64_eapis &&) = default;
-    exit_handler_intel_x64_eapis &operator=(exit_handler_intel_x64_eapis &&) = default;
+    exit_handler(exit_handler &&) = default;
+    exit_handler &operator=(exit_handler &&) = default;
 
-    exit_handler_intel_x64_eapis(const exit_handler_intel_x64_eapis &) = delete;
-    exit_handler_intel_x64_eapis &operator=(const exit_handler_intel_x64_eapis &) = delete;
+    exit_handler(const exit_handler &) = delete;
+    exit_handler &operator=(const exit_handler &) = delete;
 
     /// @endcond
 };
+
+}
+}
+}
+}
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/include/hve/arch/intel_x64/exit_handler/io_instruction_verifiers.h
+++ b/include/hve/arch/intel_x64/exit_handler/io_instruction_verifiers.h
@@ -25,6 +25,8 @@
 #include "../../../../hve/arch/intel_x64/exit_handler/exit_handler.h"
 #include "../../../../hve/arch/intel_x64/exit_handler/verifiers.h"
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 /// @cond
 
 // -----------------------------------------------------------------------------
@@ -83,7 +85,7 @@ public:
     default_verifier__trap_on_io_access() = default;
     ~default_verifier__trap_on_io_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::port_type port)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::port_type port)
     { bfignored(port); return default_verify(); }
 };
 
@@ -105,7 +107,7 @@ public:
     default_verifier__pass_through_io_access() = default;
     ~default_verifier__pass_through_io_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::port_type port)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::port_type port)
     { bfignored(port); return default_verify(); }
 };
 
@@ -127,7 +129,7 @@ public:
     default_verifier__whitelist_io_access() = default;
     ~default_verifier__whitelist_io_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::port_list_type ports)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::port_list_type ports)
     { bfignored(ports); return default_verify(); }
 };
 
@@ -138,7 +140,7 @@ public:
     default_verifier__blacklist_io_access() = default;
     ~default_verifier__blacklist_io_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::port_list_type ports)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::port_list_type ports)
     { bfignored(ports); return default_verify(); }
 };
 

--- a/include/hve/arch/intel_x64/exit_handler/rdmsr_verifiers.h
+++ b/include/hve/arch/intel_x64/exit_handler/rdmsr_verifiers.h
@@ -25,6 +25,8 @@
 #include "../../../../hve/arch/intel_x64/exit_handler/exit_handler.h"
 #include "../../../../hve/arch/intel_x64/exit_handler/verifiers.h"
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 /// @cond
 
 // -----------------------------------------------------------------------------
@@ -71,7 +73,7 @@ public:
     default_verifier__trap_on_rdmsr_access() = default;
     ~default_verifier__trap_on_rdmsr_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::msr_type msr)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::msr_type msr)
     { bfignored(msr); return default_verify(); }
 };
 
@@ -93,7 +95,7 @@ public:
     default_verifier__pass_through_rdmsr_access() = default;
     ~default_verifier__pass_through_rdmsr_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::msr_type msr)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::msr_type msr)
     { bfignored(msr); return default_verify(); }
 };
 
@@ -115,7 +117,7 @@ public:
     default_verifier__whitelist_rdmsr_access() = default;
     ~default_verifier__whitelist_rdmsr_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::msr_list_type msrs)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::msr_list_type msrs)
     { bfignored(msrs); return default_verify(); }
 };
 
@@ -126,7 +128,7 @@ public:
     default_verifier__blacklist_rdmsr_access() = default;
     ~default_verifier__blacklist_rdmsr_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::msr_list_type msrs)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::msr_list_type msrs)
     { bfignored(msrs); return default_verify(); }
 };
 

--- a/include/hve/arch/intel_x64/exit_handler/wrmsr_verifiers.h
+++ b/include/hve/arch/intel_x64/exit_handler/wrmsr_verifiers.h
@@ -25,6 +25,8 @@
 #include "../../../../hve/arch/intel_x64/exit_handler/exit_handler.h"
 #include "../../../../hve/arch/intel_x64/exit_handler/verifiers.h"
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 /// @cond
 
 // -----------------------------------------------------------------------------
@@ -71,7 +73,7 @@ public:
     default_verifier__trap_on_wrmsr_access() = default;
     ~default_verifier__trap_on_wrmsr_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::msr_type msr)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::msr_type msr)
     { bfignored(msr); return default_verify(); }
 };
 
@@ -93,7 +95,7 @@ public:
     default_verifier__pass_through_wrmsr_access() = default;
     ~default_verifier__pass_through_wrmsr_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::msr_type msr)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::msr_type msr)
     { bfignored(msr); return default_verify(); }
 };
 
@@ -115,7 +117,7 @@ public:
     default_verifier__whitelist_wrmsr_access() = default;
     ~default_verifier__whitelist_wrmsr_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::msr_list_type msrs)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::msr_list_type msrs)
     { bfignored(msrs); return default_verify(); }
 };
 
@@ -126,7 +128,7 @@ public:
     default_verifier__blacklist_wrmsr_access() = default;
     ~default_verifier__blacklist_wrmsr_access() override = default;
 
-    virtual verifier_result verify(exit_handler_intel_x64_eapis::msr_list_type msrs)
+    virtual verifier_result verify(exit_handler_eapis::exit_handler::msr_list_type msrs)
     { bfignored(msrs); return default_verify(); }
 };
 

--- a/include/hve/arch/intel_x64/vmcs/apic.h
+++ b/include/hve/arch/intel_x64/vmcs/apic.h
@@ -53,17 +53,24 @@
 ///
 /// TODO:
 ///
-class EXPORT_EAPIS_HVE apic_intel_x64
+namespace eapis
+{
+namespace hve
+{
+namespace intel_x64
+{
+
+class EXPORT_EAPIS_HVE apic
 {
 public:
 
     /// Default Constructor
     ///
-    apic_intel_x64();
+    apic();
 
     /// Default Destructor
     ///
-    ~apic_intel_x64() = default;
+    ~apic() = default;
 
 public:
 
@@ -224,14 +231,18 @@ public:
 
     /// @cond
 
-    apic_intel_x64(apic_intel_x64 &&) noexcept = default;
-    apic_intel_x64 &operator=(apic_intel_x64 &&) noexcept = default;
+    apic(apic &&) noexcept = default;
+    apic &operator=(apic &&) noexcept = default;
 
-    apic_intel_x64(const apic_intel_x64 &) = delete;
-    apic_intel_x64 &operator=(const apic_intel_x64 &) = delete;
+    apic(const apic &) = delete;
+    apic &operator=(const apic &) = delete;
 
     /// @endcond
 
 };
+
+}
+}
+}
 
 #endif

--- a/include/hve/arch/intel_x64/vmcs/ept.h
+++ b/include/hve/arch/intel_x64/vmcs/ept.h
@@ -61,7 +61,14 @@
 ///
 /// Defines an Extended Page Table
 ///
-class EXPORT_EAPIS_HVE ept_intel_x64
+namespace eapis
+{
+namespace hve
+{
+namespace intel_x64
+{
+
+class EXPORT_EAPIS_HVE ept
 {
 public:
 
@@ -83,14 +90,14 @@ public:
     /// @param epte the parent extended page table entry that points to this
     ///     table
     ///
-    ept_intel_x64(pointer epte = nullptr);
+    ept(pointer epte = nullptr);
 
     /// Destructor
     ///
     /// @expects none
     /// @ensures none
     ///
-    ~ept_intel_x64() = default;
+    ~ept() = default;
 
     ///
     /// Get an EPT entry
@@ -103,7 +110,7 @@ public:
     /// @param index the index of the entry to retrieve
     /// @return an entry object constructed from the data at @param index.
     ///
-    ept_entry_intel_x64 get_entry(index_type index);
+    ept_entry get_entry(index_type index);
 
     /// Add Page (1G Granularity)
     ///
@@ -130,8 +137,8 @@ public:
     /// @param gpa the guest physical address of the page to add
     /// @return the resulting epte.
     ///
-    ept_entry_intel_x64 add_page_1g(integer_pointer gpa)
-    { return add_page(gpa, intel_x64::ept::pml4::from, intel_x64::ept::pdpt::from); }
+    ept_entry add_page_1g(integer_pointer gpa)
+    { return add_page(gpa, ::intel_x64::ept::pml4::from, ::intel_x64::ept::pdpt::from); }
 
     /// Add Page (2M Granularity)
     ///
@@ -158,8 +165,8 @@ public:
     /// @param gpa the guest physical address of the page to add
     /// @return the resulting epte.
     ///
-    ept_entry_intel_x64 add_page_2m(integer_pointer gpa)
-    { return add_page(gpa, intel_x64::ept::pml4::from, intel_x64::ept::pd::from); }
+    ept_entry add_page_2m(integer_pointer gpa)
+    { return add_page(gpa, ::intel_x64::ept::pml4::from, ::intel_x64::ept::pd::from); }
 
     /// Add Page (4K Granularity)
     ///
@@ -184,8 +191,8 @@ public:
     /// @param gpa the guest physical address of the page to add
     /// @return the resulting epte.
     ///
-    ept_entry_intel_x64 add_page_4k(integer_pointer gpa)
-    { return add_page(gpa, intel_x64::ept::pml4::from, intel_x64::ept::pt::from); }
+    ept_entry add_page_4k(integer_pointer gpa)
+    { return add_page(gpa, ::intel_x64::ept::pml4::from, ::intel_x64::ept::pt::from); }
 
     /// Remove Page
     ///
@@ -201,7 +208,7 @@ public:
     /// @param gpa the guest physical address of the page to remove
     ///
     void remove_page(integer_pointer gpa)
-    { remove_page(gpa, intel_x64::ept::pml4::from); }
+    { remove_page(gpa, ::intel_x64::ept::pml4::from); }
 
     /// Find Extended Page Table Entry
     ///
@@ -213,8 +220,8 @@ public:
     /// @param gpa the guest physical address of the page to lookup
     /// @return returns the EPT entry for the provided gpa or throws
     ///
-    ept_entry_intel_x64 gpa_to_epte(integer_pointer gpa) const
-    { return gpa_to_epte(gpa, intel_x64::ept::pml4::from); }
+    ept_entry gpa_to_epte(integer_pointer gpa) const
+    { return gpa_to_epte(gpa, ::intel_x64::ept::pml4::from); }
 
     /// Extended Page Table to Memory Descriptor List
     ///
@@ -237,9 +244,9 @@ private:
 
     /// @cond
 
-    ept_entry_intel_x64 add_page(integer_pointer gpa, integer_pointer bits, integer_pointer end);
+    ept_entry add_page(integer_pointer gpa, integer_pointer bits, integer_pointer end);
     void remove_page(integer_pointer gpa, integer_pointer bits);
-    ept_entry_intel_x64 gpa_to_epte(integer_pointer gpa, integer_pointer bits) const;
+    ept_entry gpa_to_epte(integer_pointer gpa, integer_pointer bits) const;
     memory_descriptor_list ept_to_mdl(memory_descriptor_list &mdl) const;
 
     bool empty() const noexcept;
@@ -251,20 +258,24 @@ private:
 private:
 
     std::unique_ptr<integer_pointer[]> m_ept;               ///< The allocated EPT
-    std::vector<std::unique_ptr<ept_intel_x64>> m_epts;     ///< List of EPTs this EPT points to
+    std::vector<std::unique_ptr<ept>> m_epts;     ///< List of EPTs this EPT points to
 
 public:
 
     /// @cond
 
-    ept_intel_x64(ept_intel_x64 &&) noexcept = default;
-    ept_intel_x64 &operator=(ept_intel_x64 &&) noexcept = default;
+    ept(ept &&) noexcept = default;
+    ept &operator=(ept &&) noexcept = default;
 
-    ept_intel_x64(const ept_intel_x64 &) = delete;
-    ept_intel_x64 &operator=(const ept_intel_x64 &) = delete;
+    ept(const ept &) = delete;
+    ept &operator=(const ept &) = delete;
 
     /// @endcond
 };
+
+}
+}
+}
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/include/hve/arch/intel_x64/vmcs/ept_entry.h
+++ b/include/hve/arch/intel_x64/vmcs/ept_entry.h
@@ -111,7 +111,14 @@ namespace ept
 ///
 /// Defines an entry in an EPT table.
 ///
-class EXPORT_EAPIS_HVE ept_entry_intel_x64
+namespace eapis
+{
+namespace hve
+{
+namespace intel_x64
+{
+
+class EXPORT_EAPIS_HVE ept_entry
 {
 public:
 
@@ -127,14 +134,14 @@ public:
     ///
     /// @param pte the pte that this page table entry encapsulates.
     ///
-    ept_entry_intel_x64(gsl::not_null<pointer> pte) noexcept;
+    ept_entry(gsl::not_null<pointer> pte) noexcept;
 
     /// Destructor
     ///
     /// @expects none
     /// @ensures none
     ///
-    ~ept_entry_intel_x64() = default;
+    ~ept_entry() = default;
 
     /// EPTE pointer
     ///
@@ -405,13 +412,17 @@ public:
 
     /// @cond
 
-    ept_entry_intel_x64(ept_entry_intel_x64 &&) noexcept = default;
-    ept_entry_intel_x64 &operator=(ept_entry_intel_x64 &&) noexcept = default;
+    ept_entry(ept_entry &&) noexcept = default;
+    ept_entry &operator=(ept_entry &&) noexcept = default;
 
-    ept_entry_intel_x64(const ept_entry_intel_x64 &) = delete;
-    ept_entry_intel_x64 &operator=(const ept_entry_intel_x64 &) = delete;
+    ept_entry(const ept_entry &) = delete;
+    ept_entry &operator=(const ept_entry &) = delete;
 
     /// @endcond
 };
+
+}
+}
+}
 
 #endif

--- a/include/hve/arch/intel_x64/vmcs/root_ept.h
+++ b/include/hve/arch/intel_x64/vmcs/root_ept.h
@@ -67,30 +67,37 @@
 /// This needs to be done manually. In general, this class should not be used
 /// directly, but instead mapping should be done via a unique_map_ptr_x64.
 ///
-class EXPORT_EAPIS_HVE root_ept_intel_x64
+namespace eapis
+{
+namespace hve
+{
+namespace intel_x64
+{
+
+class EXPORT_EAPIS_HVE root_ept
 {
 public:
 
     using pointer = void *;                                                 ///< Pointer type
     using integer_pointer = uintptr_t;                                      ///< Integer pointer type
     using eptp_type = uint64_t;                                             ///< EPTP type
-    using attr_type = intel_x64::ept::memory_attr::attr_type;               ///< Memory attribute type
+    using attr_type = ::intel_x64::ept::memory_attr::attr_type;               ///< Memory attribute type
     using size_type = size_t;                                               ///< Size type
-    using memory_descriptor_list = ept_intel_x64::memory_descriptor_list;   ///< Memory descriptor list type
+    using memory_descriptor_list = ept::memory_descriptor_list;   ///< Memory descriptor list type
 
     /// Default Constructor
     ///
     /// @expects none
     /// @ensures none
     ///
-    root_ept_intel_x64();
+    root_ept();
 
     /// Default Destructor
     ///
     /// @expects none
     /// @ensures none
     ///
-    virtual ~root_ept_intel_x64() = default;
+    virtual ~root_ept() = default;
 
     /// Extended Page Table Pointer
     ///
@@ -108,7 +115,7 @@ public:
     /// physical address, the physical address and a set of attributes.
     ///
     /// @note: the user should ensure that this level of page granularity is
-    ///     supported by hardware using intel_x64::msrs::ia32_vmx_ept_vpid_cap
+    ///     supported by hardware using ::intel_x64::msrs::ia32_vmx_ept_vpid_cap
     ///
     /// @expects
     /// @ensures
@@ -118,7 +125,7 @@ public:
     /// @param attr describes how to map the gpa
     ///
     void map_1g(integer_pointer gpa, integer_pointer phys, attr_type attr)
-    { this->map_page(gpa, phys, attr, intel_x64::ept::pdpt::size_bytes); }
+    { this->map_page(gpa, phys, attr, ::intel_x64::ept::pdpt::size_bytes); }
 
     /// Map (2 Megabytes)
     ///
@@ -126,7 +133,7 @@ public:
     /// physical address, the physical address and a set of attributes.
     ///
     /// @note: the user should ensure that this level of page granularity is
-    ///     supported by hardware using intel_x64::msrs::ia32_vmx_ept_vpid_cap
+    ///     supported by hardware using ::intel_x64::msrs::ia32_vmx_ept_vpid_cap
     ///
     /// @expects
     /// @ensures
@@ -136,7 +143,7 @@ public:
     /// @param attr describes how to map the gpa
     ///
     void map_2m(integer_pointer gpa, integer_pointer phys, attr_type attr)
-    { this->map_page(gpa, phys, attr, intel_x64::ept::pd::size_bytes); }
+    { this->map_page(gpa, phys, attr, ::intel_x64::ept::pd::size_bytes); }
 
     /// Map (4 Kilobytes)
     ///
@@ -144,7 +151,7 @@ public:
     /// physical address, the physical address and a set of attributes.
     ///
     /// @note: the user should ensure that this level of page granularity is
-    ///     supported by hardware using intel_x64::msrs::ia32_vmx_ept_vpid_cap
+    ///     supported by hardware using ::intel_x64::msrs::ia32_vmx_ept_vpid_cap
     ///
     /// @expects
     /// @ensures
@@ -154,7 +161,7 @@ public:
     /// @param attr describes how to map the gpa
     ///
     void map_4k(integer_pointer gpa, integer_pointer phys, attr_type attr)
-    { this->map_page(gpa, phys, attr, intel_x64::ept::pt::size_bytes); }
+    { this->map_page(gpa, phys, attr, ::intel_x64::ept::pt::size_bytes); }
 
     /// Unmap
     ///
@@ -260,7 +267,7 @@ public:
     /// @param gpa the guest physical address to lookup
     /// @return the resulting EPTE
     ///
-    ept_entry_intel_x64 gpa_to_epte(integer_pointer gpa) const;
+    ept_entry gpa_to_epte(integer_pointer gpa) const;
 
     /// Extended Page Table to Memory Descriptor List
     ///
@@ -281,7 +288,7 @@ private:
 
     /// @cond
 
-    ept_entry_intel_x64 add_page(integer_pointer gpa, size_type size);
+    ept_entry add_page(integer_pointer gpa, size_type size);
 
     void map_page(integer_pointer gpa, integer_pointer phys, attr_type attr, size_type size);
     void unmap_page(integer_pointer gpa) noexcept;
@@ -291,7 +298,7 @@ private:
 private:
 
     integer_pointer m_eptp{0};                          ///< Integer pointer to the EPTP for this root EPT
-    std::unique_ptr<ept_intel_x64> m_ept;               ///< The root EPT
+    std::unique_ptr<ept> m_ept;               ///< The root EPT
 
     mutable std::mutex m_mutex;                         ///< Mutex for root operations
 
@@ -299,14 +306,18 @@ public:
 
     /// @cond
 
-    root_ept_intel_x64(root_ept_intel_x64 &&) = default;
-    root_ept_intel_x64 &operator=(root_ept_intel_x64 &&) = default;
+    root_ept(root_ept &&) = default;
+    root_ept &operator=(root_ept &&) = default;
 
-    root_ept_intel_x64(const root_ept_intel_x64 &) = delete;
-    root_ept_intel_x64 &operator=(const root_ept_intel_x64 &) = delete;
+    root_ept(const root_ept &) = delete;
+    root_ept &operator=(const root_ept &) = delete;
 
     /// @endcond
 };
+
+}
+}
+}
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/include/hve/arch/intel_x64/vmcs/vmcs.h
+++ b/include/hve/arch/intel_x64/vmcs/vmcs.h
@@ -75,32 +75,41 @@
 /// Defines the EAPIs version of the VMCS. Note that this is intended to be
 /// subclassed.
 ///
-class EXPORT_EAPIS_HVE vmcs_intel_x64_eapis : public vmcs_intel_x64
+namespace eapis
+{
+namespace hve
+{
+namespace intel_x64
+{
+namespace vmcs
+{
+
+class EXPORT_EAPIS_HVE vmcs : public bfvmm::intel_x64::vmcs
 {
 public:
 
     using integer_pointer = uintptr_t;                      ///< Integer pointer type
-    using port_type = x64::portio::port_addr_type;          ///< Port type
+    using port_type = ::x64::portio::port_addr_type;          ///< Port type
     using port_list_type = std::vector<port_type>;          ///< Port list type
-    using msr_type = x64::msrs::field_type;                 ///< MSR type
+    using msr_type = ::x64::msrs::field_type;                 ///< MSR type
     using msr_list_type = std::vector<msr_type>;            ///< MSR list type
-    using mask_type = intel_x64::vmcs::value_type;          ///< CR Mask type
-    using shadow_type = intel_x64::vmcs::value_type;        ///< CR shadow type
-    using eptp_type = intel_x64::vmcs::value_type;          ///< CR shadow type
+    using mask_type = ::intel_x64::vmcs::value_type;          ///< CR Mask type
+    using shadow_type = ::intel_x64::vmcs::value_type;        ///< CR shadow type
+    using eptp_type = ::intel_x64::vmcs::value_type;          ///< CR shadow type
 
     /// Default Constructor
     ///
     /// @expects
     /// @ensures
     ///
-    vmcs_intel_x64_eapis();
+    vmcs();
 
     /// Destructor
     ///
     /// @expects
     /// @ensures
     ///
-    ~vmcs_intel_x64_eapis() override  = default;
+    ~vmcs() override  = default;
 
     /// Enable VPID
     ///
@@ -284,7 +293,7 @@ public:
     /// @ensures
     ///
     /// @param eptp the eptp value to use. This should come from the
-    ///     root_ept_intel_x64->eptp() function.
+    ///     root_ept->eptp() function.
     ///
     virtual void enable_ept(eptp_type eptp);
 
@@ -316,7 +325,7 @@ public:
     /// @ensures
     ///
     /// @param eptp the eptp value to use. This should come from the
-    ///     root_ept_intel_x64->eptp() function.
+    ///     root_ept->eptp() function.
     ///
     virtual void set_eptp(eptp_type eptp);
 
@@ -692,7 +701,7 @@ public:
 protected:
 #endif
 
-    intel_x64::vmcs::value_type m_vpid;             ///< VPID for this VMCS
+    ::intel_x64::vmcs::value_type m_vpid;             ///< VPID for this VMCS
 
     std::unique_ptr<uint8_t[]> m_io_bitmapa;        ///< IO bitmap A
     std::unique_ptr<uint8_t[]> m_io_bitmapb;        ///< IO bitmap B
@@ -805,21 +814,26 @@ protected:
     /// @param host_state pointer to host state
     /// @param guest_state pointer to guest state
     ///
-    virtual void write_fields(gsl::not_null<vmcs_intel_x64_state *> host_state,
-                      gsl::not_null<vmcs_intel_x64_state *> guest_state);
+    virtual void write_fields(gsl::not_null<bfvmm::intel_x64::vmcs_state *> host_state,
+                              gsl::not_null<bfvmm::intel_x64::vmcs_state *> guest_state);
 
 public:
 
     /// @cond
 
-    vmcs_intel_x64_eapis(vmcs_intel_x64_eapis &&) = default;
-    vmcs_intel_x64_eapis &operator=(vmcs_intel_x64_eapis &&) = default;
+    vmcs(vmcs &&) = default;
+    vmcs &operator=(vmcs &&) = default;
 
-    vmcs_intel_x64_eapis(const vmcs_intel_x64_eapis &) = delete;
-    vmcs_intel_x64_eapis &operator=(const vmcs_intel_x64_eapis &) = delete;
+    vmcs(const vmcs &) = delete;
+    vmcs &operator=(const vmcs &) = delete;
 
     /// @endcond
 };
+
+}
+}
+}
+}
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/include/hve/arch/intel_x64/vmcs/vmcs_vmm_state.h
+++ b/include/hve/arch/intel_x64/vmcs/vmcs_vmm_state.h
@@ -51,30 +51,43 @@
 /// is used here except the constructor, were EAPI specific resources are
 /// initialized.
 ///
-class EXPORT_EAPIS_HVE vmcs_intel_x64_vmm_state_eapis :
-    public vmcs_intel_x64_vmm_state
+namespace eapis
+{
+namespace hve
+{
+namespace intel_x64
+{
+namespace vmcs
+{
+
+class EXPORT_EAPIS_HVE vmcs_state_vmm : public bfvmm::intel_x64::vmcs_state_vmm
 {
 public:
 
     /// Default Constructor
     ///
-    vmcs_intel_x64_vmm_state_eapis();
+    vmcs_state_vmm();
 
     /// Default Destructor
     ///
-    ~vmcs_intel_x64_vmm_state_eapis() override = default;
+    ~vmcs_state_vmm() override = default;
 
 public:
 
     /// @cond
 
-    vmcs_intel_x64_vmm_state_eapis(vmcs_intel_x64_vmm_state_eapis &&) noexcept = delete;
-    vmcs_intel_x64_vmm_state_eapis &operator=(vmcs_intel_x64_vmm_state_eapis &&) noexcept = delete;
+    vmcs_state_vmm(vmcs_state_vmm &&) noexcept = delete;
+    vmcs_state_vmm &operator=(vmcs_state_vmm &&) noexcept = delete;
 
-    vmcs_intel_x64_vmm_state_eapis(const vmcs_intel_x64_vmm_state_eapis &) = delete;
-    vmcs_intel_x64_vmm_state_eapis &operator=(const vmcs_intel_x64_vmm_state_eapis &) = delete;
+    vmcs_state_vmm(const vmcs_state_vmm &) = delete;
+    vmcs_state_vmm &operator=(const vmcs_state_vmm &) = delete;
 
     /// @endcond
 };
+
+}
+}
+}
+}
 
 #endif

--- a/src/hve/arch/intel_x64/exit_handler/cpuid_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/cpuid_emulation.cpp
@@ -23,16 +23,18 @@
 
 #include <bfvmm/hve/arch/intel_x64/state_save.h>
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 void
-exit_handler_intel_x64_eapis::log_cpuid_access(bool enable)
+exit_handler_eapis::exit_handler::log_cpuid_access(bool enable)
 { m_cpuid_access_log_enabled = enable; }
 
 void
-exit_handler_intel_x64_eapis::clear_cpuid_access_log()
+exit_handler_eapis::exit_handler::clear_cpuid_access_log()
 { m_cpuid_access_log.clear(); }
 
 void
-exit_handler_intel_x64_eapis::handle_exit__cpuid()
+exit_handler_eapis::exit_handler::handle_exit__cpuid()
 {
     cpuid_key_type leaf = m_state_save->rax;
     cpuid_key_type subleaf = m_state_save->rcx;

--- a/src/hve/arch/intel_x64/exit_handler/cpuid_vmcall.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/cpuid_vmcall.cpp
@@ -27,8 +27,10 @@
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/verifiers.h"
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/cpuid_verifiers.h"
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 void
-exit_handler_intel_x64_eapis::register_json_vmcall__cpuid()
+exit_handler_eapis::exit_handler::register_json_vmcall__cpuid()
 {
     m_json_commands["emulate_cpuid"] = [&](const auto & ijson, auto & ojson) {
         this->handle_vmcall__emulate_cpuid(json_hex_or_dec<cpuid_type>(ijson, "leaf"),
@@ -68,14 +70,14 @@ exit_handler_intel_x64_eapis::register_json_vmcall__cpuid()
 }
 
 uint64_t
-exit_handler_intel_x64_eapis::create_key(
+exit_handler_eapis::exit_handler::create_key(
     cpuid_key_type leaf, cpuid_key_type subleaf)
 {
     return (leaf << 32) | subleaf;
 }
 
 uint64_t
-exit_handler_intel_x64_eapis::parse_emulate_cpuid_string(
+exit_handler_eapis::exit_handler::parse_emulate_cpuid_string(
     std::string reg_string, cpuid_key_type machine_reg)
 {
     cpuid_key_type defined_mask = 0;
@@ -109,7 +111,7 @@ exit_handler_intel_x64_eapis::parse_emulate_cpuid_string(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__emulate_cpuid(
+exit_handler_eapis::exit_handler::handle_vmcall__emulate_cpuid(
     cpuid_type leaf, cpuid_type subleaf,
     std::string eax, std::string ebx, std::string ecx, std::string edx)
 {
@@ -136,7 +138,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__emulate_cpuid(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__reset_cpuid_leaf(
+exit_handler_eapis::exit_handler::handle_vmcall__reset_cpuid_leaf(
     cpuid_type leaf, cpuid_type subleaf)
 {
     if (policy(reset_cpuid_leaf)->verify(leaf, subleaf) != vmcall_verifier::allow) {
@@ -152,7 +154,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__reset_cpuid_leaf(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__reset_cpuid_all()
+exit_handler_eapis::exit_handler::handle_vmcall__reset_cpuid_all()
 {
     if (policy(reset_cpuid_all)->verify() != vmcall_verifier::allow) {
         policy(reset_cpuid_all)->deny_vmcall();
@@ -164,7 +166,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__reset_cpuid_all()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__log_cpuid_access(
+exit_handler_eapis::exit_handler::handle_vmcall__log_cpuid_access(
     bool enabled)
 {
     if (policy(log_cpuid_access)->verify(enabled) != vmcall_verifier::allow) {
@@ -177,7 +179,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__log_cpuid_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__clear_cpuid_access_log()
+exit_handler_eapis::exit_handler::handle_vmcall__clear_cpuid_access_log()
 {
     if (policy(clear_cpuid_access_log)->verify() != vmcall_verifier::allow) {
         policy(clear_cpuid_access_log)->deny_vmcall();
@@ -189,7 +191,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__clear_cpuid_access_log()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__cpuid_access_log(
+exit_handler_eapis::exit_handler::handle_vmcall__cpuid_access_log(
     json &ojson)
 {
     if (policy(cpuid_access_log)->verify() != vmcall_verifier::allow) {
@@ -204,7 +206,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__cpuid_access_log(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__dump_cpuid_emulations_log(
+exit_handler_eapis::exit_handler::handle_vmcall__dump_cpuid_emulations_log(
     json &ojson)
 {
     if (policy(dump_cpuid_emulations_log)->verify() != vmcall_verifier::allow) {

--- a/src/hve/arch/intel_x64/exit_handler/cr_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/cr_emulation.cpp
@@ -26,10 +26,8 @@
 #include <arch/intel_x64/vmcs/natural_width_guest_state_fields.h>
 #include <arch/intel_x64/crs.h>
 
-namespace intel = ::intel_x64;
-namespace vmcs = ::intel_x64::vmcs;
-namespace cr_access = vmcs::exit_qualification::control_register_access;
-namespace gpr = gpr;
+namespace cr_access = ::intel_x64::vmcs::exit_qualification::control_register_access;
+namespace gpr = cr_access::general_purpose_register;
 namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 exit_handler_eapis::exit_handler::gpr_value_type
@@ -172,7 +170,7 @@ exit_handler_eapis::exit_handler::handle_exit__ctl_reg_access()
     switch (cr_access::control_register_number::get()) {
         case 0: {
             auto ret = this->cr0_ld_callback(this->get_gpr(index));
-            vmcs::guest_cr0::set(ret);
+            ::intel_x64::vmcs::guest_cr0::set(ret);
 
             this->advance_and_resume();
             return;
@@ -182,14 +180,14 @@ exit_handler_eapis::exit_handler::handle_exit__ctl_reg_access()
             switch (type) {
                 case cr_access::access_type::mov_to_cr: {
                     auto ret = this->cr3_ld_callback(this->get_gpr(index));
-                    vmcs::guest_cr3::set(ret);
+                    ::intel_x64::vmcs::guest_cr3::set(ret);
 
                     this->advance_and_resume();
                     return;
                 }
 
                 case cr_access::access_type::mov_from_cr: {
-                    auto ret = this->cr3_st_callback(vmcs::guest_cr3::get());
+                    auto ret = this->cr3_st_callback(::intel_x64::vmcs::guest_cr3::get());
                     this->set_gpr(index, ret);
 
                     this->advance_and_resume();
@@ -201,7 +199,7 @@ exit_handler_eapis::exit_handler::handle_exit__ctl_reg_access()
 
         case 4: {
             auto ret = this->cr4_ld_callback(this->get_gpr(index));
-            vmcs::guest_cr4::set(ret);
+            ::intel_x64::vmcs::guest_cr4::set(ret);
 
             this->advance_and_resume();
             return;
@@ -211,14 +209,14 @@ exit_handler_eapis::exit_handler::handle_exit__ctl_reg_access()
             switch (type) {
                 case cr_access::access_type::mov_to_cr: {
                     auto ret = this->cr8_ld_callback(this->get_gpr(index));
-                    intel::cr8::set(ret);
+                    ::intel_x64::cr8::set(ret);
 
                     this->advance_and_resume();
                     return;
                 }
 
                 case cr_access::access_type::mov_from_cr: {
-                    auto ret = this->cr8_st_callback(intel::cr8::get());
+                    auto ret = this->cr8_st_callback(::intel_x64::cr8::get());
                     this->set_gpr(index, ret);
 
                     this->advance_and_resume();

--- a/src/hve/arch/intel_x64/exit_handler/cr_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/cr_emulation.cpp
@@ -26,62 +26,60 @@
 #include <arch/intel_x64/vmcs/natural_width_guest_state_fields.h>
 #include <arch/intel_x64/crs.h>
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
-using namespace exit_qualification::control_register_access;
+namespace cr_access = ::intel_x64::vmcs::exit_qualification::control_register_access;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
-exit_handler_intel_x64_eapis::gpr_value_type
-exit_handler_intel_x64_eapis::get_gpr(gpr_index_type index)
+exit_handler_eapis::exit_handler::gpr_value_type
+exit_handler_eapis::exit_handler::get_gpr(gpr_index_type index)
 {
     switch (index)
     {
-        case general_purpose_register::rax:
+        case cr_access::general_purpose_register::rax:
             return m_state_save->rax;
 
-        case general_purpose_register::rbx:
+        case cr_access::general_purpose_register::rbx:
             return m_state_save->rbx;
 
-        case general_purpose_register::rcx:
+        case cr_access::general_purpose_register::rcx:
             return m_state_save->rcx;
 
-        case general_purpose_register::rdx:
+        case cr_access::general_purpose_register::rdx:
             return m_state_save->rdx;
 
-        case general_purpose_register::rsp:
+        case cr_access::general_purpose_register::rsp:
             return m_state_save->rsp;
 
-        case general_purpose_register::rbp:
+        case cr_access::general_purpose_register::rbp:
             return m_state_save->rbp;
 
-        case general_purpose_register::rsi:
+        case cr_access::general_purpose_register::rsi:
             return m_state_save->rsi;
 
-        case general_purpose_register::rdi:
+        case cr_access::general_purpose_register::rdi:
             return m_state_save->rdi;
 
-        case general_purpose_register::r8:
+        case cr_access::general_purpose_register::r8:
             return m_state_save->r08;
 
-        case general_purpose_register::r9:
+        case cr_access::general_purpose_register::r9:
             return m_state_save->r09;
 
-        case general_purpose_register::r10:
+        case cr_access::general_purpose_register::r10:
             return m_state_save->r10;
 
-        case general_purpose_register::r11:
+        case cr_access::general_purpose_register::r11:
             return m_state_save->r11;
 
-        case general_purpose_register::r12:
+        case cr_access::general_purpose_register::r12:
             return m_state_save->r12;
 
-        case general_purpose_register::r13:
+        case cr_access::general_purpose_register::r13:
             return m_state_save->r13;
 
-        case general_purpose_register::r14:
+        case cr_access::general_purpose_register::r14:
             return m_state_save->r14;
 
-        case general_purpose_register::r15:
+        case cr_access::general_purpose_register::r15:
             return m_state_save->r15;
     }
 
@@ -90,72 +88,72 @@ exit_handler_intel_x64_eapis::get_gpr(gpr_index_type index)
 
 
 void
-exit_handler_intel_x64_eapis::set_gpr(
+exit_handler_eapis::exit_handler::set_gpr(
     gpr_index_type index, gpr_value_type val)
 {
     switch (index)
     {
-        case general_purpose_register::rax:
+        case cr_access::general_purpose_register::rax:
             m_state_save->rax = val;
             return;
 
-        case general_purpose_register::rbx:
+        case cr_access::general_purpose_register::rbx:
             m_state_save->rbx = val;
             return;
 
-        case general_purpose_register::rcx:
+        case cr_access::general_purpose_register::rcx:
             m_state_save->rcx = val;
             return;
 
-        case general_purpose_register::rdx:
+        case cr_access::general_purpose_register::rdx:
             m_state_save->rdx = val;
             return;
 
-        case general_purpose_register::rsp:
+        case cr_access::general_purpose_register::rsp:
             m_state_save->rsp = val;
             return;
 
-        case general_purpose_register::rbp:
+        case cr_access::general_purpose_register::rbp:
             m_state_save->rbp = val;
             return;
 
-        case general_purpose_register::rsi:
+        case cr_access::general_purpose_register::rsi:
             m_state_save->rsi = val;
             return;
 
-        case general_purpose_register::rdi:
+        case cr_access::general_purpose_register::rdi:
             m_state_save->rdi = val;
             return;
 
-        case general_purpose_register::r8:
+        case cr_access::general_purpose_register::r8:
             m_state_save->r08 = val;
             return;
 
-        case general_purpose_register::r9:
+        case cr_access::general_purpose_register::r9:
             m_state_save->r09 = val;
             return;
 
-        case general_purpose_register::r10:
+        case cr_access::general_purpose_register::r10:
             m_state_save->r10 = val;
             return;
 
-        case general_purpose_register::r11:
+        case cr_access::general_purpose_register::r11:
             m_state_save->r11 = val;
             return;
 
-        case general_purpose_register::r12:
+        case cr_access::general_purpose_register::r12:
             m_state_save->r12 = val;
             return;
 
-        case general_purpose_register::r13:
+        case cr_access::general_purpose_register::r13:
             m_state_save->r13 = val;
             return;
 
-        case general_purpose_register::r14:
+        case cr_access::general_purpose_register::r14:
             m_state_save->r14 = val;
             return;
 
-        case general_purpose_register::r15:
+        case cr_access::general_purpose_register::r15:
             m_state_save->r15 = val;
             return;
     }
@@ -164,17 +162,17 @@ exit_handler_intel_x64_eapis::set_gpr(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_exit__ctl_reg_access()
+exit_handler_eapis::exit_handler::handle_exit__ctl_reg_access()
 {
-    auto type = access_type::get();
-    auto index = general_purpose_register::get();
+    auto type = cr_access::access_type::get();
+    auto index = cr_access::general_purpose_register::get();
 
-    switch (control_register_number::get())
+    switch (cr_access::control_register_number::get())
     {
         case 0:
         {
             auto ret = this->cr0_ld_callback(this->get_gpr(index));
-            guest_cr0::set(ret);
+            ::intel_x64::vmcs::guest_cr0::set(ret);
 
             this->advance_and_resume();
             return;
@@ -184,18 +182,18 @@ exit_handler_intel_x64_eapis::handle_exit__ctl_reg_access()
         {
             switch (type)
             {
-                case access_type::mov_to_cr:
+                case cr_access::access_type::mov_to_cr:
                 {
                     auto ret = this->cr3_ld_callback(this->get_gpr(index));
-                    guest_cr3::set(ret);
+                    ::intel_x64::vmcs::guest_cr3::set(ret);
 
                     this->advance_and_resume();
                     return;
                 }
 
-                case access_type::mov_from_cr:
+                case cr_access::access_type::mov_from_cr:
                 {
-                    auto ret = this->cr3_st_callback(guest_cr3::get());
+                    auto ret = this->cr3_st_callback(::intel_x64::vmcs::guest_cr3::get());
                     this->set_gpr(index, ret);
 
                     this->advance_and_resume();
@@ -207,7 +205,7 @@ exit_handler_intel_x64_eapis::handle_exit__ctl_reg_access()
         case 4:
         {
             auto ret = this->cr4_ld_callback(this->get_gpr(index));
-            guest_cr4::set(ret);
+            ::intel_x64::vmcs::guest_cr4::set(ret);
 
             this->advance_and_resume();
             return;
@@ -217,18 +215,18 @@ exit_handler_intel_x64_eapis::handle_exit__ctl_reg_access()
         {
             switch (type)
             {
-                case access_type::mov_to_cr:
+                case cr_access::access_type::mov_to_cr:
                 {
                     auto ret = this->cr8_ld_callback(this->get_gpr(index));
-                    cr8::set(ret);
+                    ::intel_x64::cr8::set(ret);
 
                     this->advance_and_resume();
                     return;
                 }
 
-                case access_type::mov_from_cr:
+                case cr_access::access_type::mov_from_cr:
                 {
-                    auto ret = this->cr8_st_callback(cr8::get());
+                    auto ret = this->cr8_st_callback(::intel_x64::cr8::get());
                     this->set_gpr(index, ret);
 
                     this->advance_and_resume();
@@ -245,26 +243,26 @@ exit_handler_intel_x64_eapis::handle_exit__ctl_reg_access()
     }
 }
 
-exit_handler_intel_x64_eapis::cr0_value_type
-exit_handler_intel_x64_eapis::cr0_ld_callback(cr0_value_type val)
+exit_handler_eapis::exit_handler::cr0_value_type
+exit_handler_eapis::exit_handler::cr0_ld_callback(cr0_value_type val)
 { return val; }
 
-exit_handler_intel_x64_eapis::cr3_value_type
-exit_handler_intel_x64_eapis::cr3_ld_callback(cr3_value_type val)
+exit_handler_eapis::exit_handler::cr3_value_type
+exit_handler_eapis::exit_handler::cr3_ld_callback(cr3_value_type val)
 { return val; }
 
-exit_handler_intel_x64_eapis::cr3_value_type
-exit_handler_intel_x64_eapis::cr3_st_callback(cr3_value_type val)
+exit_handler_eapis::exit_handler::cr3_value_type
+exit_handler_eapis::exit_handler::cr3_st_callback(cr3_value_type val)
 { return val; }
 
-exit_handler_intel_x64_eapis::cr4_value_type
-exit_handler_intel_x64_eapis::cr4_ld_callback(cr4_value_type val)
+exit_handler_eapis::exit_handler::cr4_value_type
+exit_handler_eapis::exit_handler::cr4_ld_callback(cr4_value_type val)
 { return val; }
 
-exit_handler_intel_x64_eapis::cr8_value_type
-exit_handler_intel_x64_eapis::cr8_ld_callback(cr8_value_type val)
+exit_handler_eapis::exit_handler::cr8_value_type
+exit_handler_eapis::exit_handler::cr8_ld_callback(cr8_value_type val)
 { return val; }
 
-exit_handler_intel_x64_eapis::cr8_value_type
-exit_handler_intel_x64_eapis::cr8_st_callback(cr8_value_type val)
+exit_handler_eapis::exit_handler::cr8_value_type
+exit_handler_eapis::exit_handler::cr8_st_callback(cr8_value_type val)
 { return val; }

--- a/src/hve/arch/intel_x64/exit_handler/event_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/event_emulation.cpp
@@ -24,16 +24,14 @@
 #include <intrinsics.h>
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/exit_handler.h"
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
-using namespace primary_processor_based_vm_execution_controls;
+namespace entry_interrupt_info = ::intel_x64::vmcs::vm_entry_interruption_information;
+namespace exit_interrupt_info = ::intel_x64::vmcs::vm_exit_interruption_information;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 static void
-set_vm_entry_interruption_information(const exit_handler_intel_x64_eapis::event &event)
+set_vm_entry_interruption_information(const exit_handler_eapis::exit_handler::event &event)
 {
-    using namespace vm_entry_interruption_information;
-
     auto eii = 0ULL;
     auto deliver_error_code = false;
 
@@ -45,12 +43,12 @@ set_vm_entry_interruption_information(const exit_handler_intel_x64_eapis::event 
     //     bfdebug_subnhex(0, "event.error_code", event.error_code, msg);
     // });
 
-    if (event.type == interruption_type::non_maskable_interrupt) {
+    if (event.type == entry_interrupt_info::interruption_type::non_maskable_interrupt) {
         bfalert_info(0, "injecting non_maskable_interrupts is not supported. request ignored");
         return;
     }
 
-    if (event.type == interruption_type::hardware_exception) {
+    if (event.type == entry_interrupt_info::interruption_type::hardware_exception) {
 
         switch (event.vector) {
             case 8:
@@ -65,22 +63,22 @@ set_vm_entry_interruption_information(const exit_handler_intel_x64_eapis::event 
         }
     }
 
-    eii = vm_entry_interruption_information::vector::set(eii, event.vector);
-    eii = vm_entry_interruption_information::interruption_type::set(eii, event.type);
-    eii = vm_entry_interruption_information::deliver_error_code_bit::set(eii, deliver_error_code);
-    eii = vm_entry_interruption_information::valid_bit::enable(eii);
+    eii = entry_interrupt_info::vector::set(eii, event.vector);
+    eii = entry_interrupt_info::interruption_type::set(eii, event.type);
+    eii = entry_interrupt_info::deliver_error_code_bit::set(eii, deliver_error_code);
+    eii = entry_interrupt_info::valid_bit::enable(eii);
 
-    vm_entry_interruption_information::set(eii);
+    entry_interrupt_info::set(eii);
 
     if (deliver_error_code) {
-        vm_entry_exception_error_code::set(event.error_code & 0x7FFF);
+        ::intel_x64::vmcs::vm_entry_exception_error_code::set(event.error_code & 0x7FFF);
     }
 
     switch (event.type) {
-        case interruption_type::software_interrupt:
-        case interruption_type::privileged_software_exception:
-        case interruption_type::software_exception:
-            vm_entry_instruction_length::set(event.len);
+        case entry_interrupt_info::interruption_type::software_interrupt:
+        case entry_interrupt_info::interruption_type::privileged_software_exception:
+        case entry_interrupt_info::interruption_type::software_exception:
+            ::intel_x64::vmcs::vm_entry_instruction_length::set(event.len);
             break;
 
         default:
@@ -89,7 +87,7 @@ set_vm_entry_interruption_information(const exit_handler_intel_x64_eapis::event 
 }
 
 void
-exit_handler_intel_x64_eapis::queue_event(
+exit_handler_eapis::exit_handler::queue_event(
     vector_type vector, event_type type, instr_len_type len, error_code_type error_code)
 {
     m_event_queue.push_back({
@@ -99,24 +97,24 @@ exit_handler_intel_x64_eapis::queue_event(
         error_code
     });
 
-    interrupt_window_exiting::enable();
+    proc_ctls::interrupt_window_exiting::enable();
 }
 
 void
-exit_handler_intel_x64_eapis::inject_event(
+exit_handler_eapis::exit_handler::inject_event(
     vector_type vector, event_type type, instr_len_type len, error_code_type error_code)
 {
-    if (vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
         return queue_event(vector, type, len, error_code);
     }
 
-    if (type == vm_entry_interruption_information::interruption_type::external_interrupt) {
+    if (type == entry_interrupt_info::interruption_type::external_interrupt) {
 
-        if (guest_rflags::interrupt_enable_flag::is_disabled()) {
+        if (::intel_x64::vmcs::guest_rflags::interrupt_enable_flag::is_disabled()) {
             return queue_event(vector, type, len, error_code);
         }
 
-        if (vmcs::guest_interruptibility_state::get() != 0) {
+        if (::intel_x64::vmcs::guest_interruptibility_state::get() != 0) {
             return queue_event(vector, type, len, error_code);
         }
     }
@@ -125,11 +123,11 @@ exit_handler_intel_x64_eapis::inject_event(
         return queue_event(vector, type, len, error_code);
     }
 
-    if (vm_entry_interruption_information::valid_bit::is_enabled()) {
+    if (entry_interrupt_info::valid_bit::is_enabled()) {
         return queue_event(vector, type, len, error_code);
     }
 
-    if (vmcs::guest_activity_state::get() != vmcs::guest_activity_state::active) {
+    if (::intel_x64::vmcs::guest_activity_state::get() != ::intel_x64::vmcs::guest_activity_state::active) {
         return queue_event(vector, type, len, error_code);
     }
 
@@ -142,32 +140,32 @@ exit_handler_intel_x64_eapis::inject_event(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_exit__external_interrupt()
+exit_handler_eapis::exit_handler::handle_exit__external_interrupt()
 {
-    auto eii = vm_exit_interruption_information::get();
+    auto eii = exit_interrupt_info::get();
 
-    if (vm_exit_interruption_information::valid_bit::is_disabled(eii)) {
+    if (exit_interrupt_info::valid_bit::is_disabled(eii)) {
         bfalert_info(0, "invalid interruption exit information. interrupt ignored");
         this->resume();
     }
 
-    if (vm_exit_interruption_information::nmi_unblocking_due_to_iret::is_enabled(eii)) {
+    if (exit_interrupt_info::nmi_unblocking_due_to_iret::is_enabled(eii)) {
         bfalert_info(0, "nmi_unblocking_due_to_iret is unsupported. interrupt ignored");
         this->resume();
     }
 
     inject_event(
-        vm_exit_interruption_information::vector::get(eii),
-        vm_exit_interruption_information::interruption_type::get(eii),
-        vm_exit_instruction_length::get(),
-        vm_exit_interruption_error_code::get()
+        exit_interrupt_info::vector::get(eii),
+        exit_interrupt_info::interruption_type::get(eii),
+        ::intel_x64::vmcs::vm_exit_instruction_length::get(),
+        ::intel_x64::vmcs::vm_exit_interruption_error_code::get()
     );
 
     this->resume();
 }
 
 void
-exit_handler_intel_x64_eapis::handle_exit__interrupt_window()
+exit_handler_eapis::exit_handler::handle_exit__interrupt_window()
 {
     if (m_event_queue.empty()) {
         bfalert_info(0, "event queue empty: interrupt window ignored");
@@ -177,22 +175,22 @@ exit_handler_intel_x64_eapis::handle_exit__interrupt_window()
     set_vm_entry_interruption_information(m_event_queue.front());
     m_event_queue.pop_front();
 
-    interrupt_window_exiting::set(!m_event_queue.empty());
+    proc_ctls::interrupt_window_exiting::set(!m_event_queue.empty());
     this->resume();
 }
 
 void
-exit_handler_intel_x64_eapis::enable_vmm_exceptions() noexcept
+exit_handler_eapis::exit_handler::enable_vmm_exceptions() noexcept
 {
-    m_tpr_shadow = cr8::get();
-    cr8::set(0x0FU);
+    m_tpr_shadow = ::intel_x64::cr8::get();
+    ::intel_x64::cr8::set(0x0FU);
 
-    rflags::interrupt_enable_flag::enable();
+    ::x64::rflags::interrupt_enable_flag::enable();
 }
 
 void
-exit_handler_intel_x64_eapis::disable_vmm_exceptions() noexcept
+exit_handler_eapis::exit_handler::disable_vmm_exceptions() noexcept
 {
-    rflags::interrupt_enable_flag::disable();
-    cr8::set(m_tpr_shadow);
+    ::x64::rflags::interrupt_enable_flag::disable();
+    ::intel_x64::cr8::set(m_tpr_shadow);
 }

--- a/src/hve/arch/intel_x64/exit_handler/event_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/event_emulation.cpp
@@ -24,15 +24,13 @@
 #include <intrinsics.h>
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/exit_handler.h"
 
-namespace intel = ::intel_x64;
-namespace vmcs = ::intel_x64::vmcs;
-namespace proc_ctls = vmcs::primary_processor_based_vm_execution_controls;
-namespace entry_irq_info = vmcs::vm_entry_interruption_information;
-namespace entry_irq_type = vmcs::vm_entry_interupption_information::interruption_type;
-namespace exit_irq_info = vmcs::vm_exit_interruption_information;
-namespace exit_irq_type = vmcs::vm_exit_interruption_information::interruption_type;
-namespace guest_irq_state = vmcs::guest_interruptibility_state;
-namespace guest_act_state = vmcs::guest_activity_state;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+namespace entry_irq_info = ::intel_x64::vmcs::vm_entry_interruption_information;
+namespace entry_irq_type = ::intel_x64::vmcs::vm_entry_interruption_information::interruption_type;
+namespace exit_irq_info = ::intel_x64::vmcs::vm_exit_interruption_information;
+namespace exit_irq_type = ::intel_x64::vmcs::vm_exit_interruption_information::interruption_type;
+namespace guest_irq_state = ::intel_x64::vmcs::guest_interruptibility_state;
+namespace guest_act_state = ::intel_x64::vmcs::guest_activity_state;
 namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 static void
@@ -77,14 +75,14 @@ set_vm_entry_interruption_information(const exit_handler_eapis::exit_handler::ev
     entry_irq_info::set(eii);
 
     if (deliver_error_code) {
-        vmcs::vm_entry_exception_error_code::set(event.error_code & 0x7FFF);
+        ::intel_x64::vmcs::vm_entry_exception_error_code::set(event.error_code & 0x7FFF);
     }
 
     switch (event.type) {
         case entry_irq_type::software_interrupt:
         case entry_irq_type::privileged_software_exception:
         case entry_irq_type::software_exception:
-            vmcs::vm_entry_instruction_length::set(event.len);
+            ::intel_x64::vmcs::vm_entry_instruction_length::set(event.len);
             break;
 
         default:
@@ -116,7 +114,7 @@ exit_handler_eapis::exit_handler::inject_event(
 
     if (type == entry_irq_type::external_interrupt) {
 
-        if (vmcs::guest_rflags::interrupt_enable_flag::is_disabled()) {
+        if (::intel_x64::vmcs::guest_rflags::interrupt_enable_flag::is_disabled()) {
             return queue_event(vector, type, len, error_code);
         }
 
@@ -133,7 +131,7 @@ exit_handler_eapis::exit_handler::inject_event(
         return queue_event(vector, type, len, error_code);
     }
 
-    if (vmcs::guest_activity_state::get() != vmcs::guest_activity_state::active) {
+    if (::intel_x64::vmcs::guest_activity_state::get() != ::intel_x64::vmcs::guest_activity_state::active) {
         return queue_event(vector, type, len, error_code);
     }
 
@@ -163,8 +161,8 @@ exit_handler_eapis::exit_handler::handle_exit__external_interrupt()
     inject_event(
         exit_irq_info::vector::get(eii),
         exit_irq_type::get(eii),
-        vmcs::vm_exit_instruction_length::get(),
-        vmcs::vm_exit_interruption_error_code::get()
+        ::intel_x64::vmcs::vm_exit_instruction_length::get(),
+        ::intel_x64::vmcs::vm_exit_interruption_error_code::get()
     );
 
     this->resume();
@@ -188,8 +186,8 @@ exit_handler_eapis::exit_handler::handle_exit__interrupt_window()
 void
 exit_handler_eapis::exit_handler::enable_vmm_exceptions() noexcept
 {
-    m_tpr_shadow = intel::cr8::get();
-    intel::cr8::set(0x0FU);
+    m_tpr_shadow = ::intel_x64::cr8::get();
+    ::intel_x64::cr8::set(0x0FU);
 
     ::x64::rflags::interrupt_enable_flag::enable();
 }
@@ -198,5 +196,5 @@ void
 exit_handler_eapis::exit_handler::disable_vmm_exceptions() noexcept
 {
     ::x64::rflags::interrupt_enable_flag::disable();
-    intel::cr8::set(m_tpr_shadow);
+    ::intel_x64::cr8::set(m_tpr_shadow);
 }

--- a/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
@@ -24,12 +24,11 @@
 
 #include <intrinsics.h>
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
+namespace exit_reason_basic = ::intel_x64::vmcs::exit_reason::basic_exit_reason;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
-exit_handler_intel_x64_eapis::exit_handler_intel_x64_eapis() :
-    m_monitor_trap_callback(&exit_handler_intel_x64_eapis::unhandled_monitor_trap_callback),
+exit_handler_eapis::exit_handler::exit_handler() :
+    m_monitor_trap_callback(&exit_handler_eapis::exit_handler::unhandled_monitor_trap_callback),
     m_io_access_log_enabled(false),
     m_vmcs_eapis(nullptr)
 {
@@ -44,51 +43,51 @@ exit_handler_intel_x64_eapis::exit_handler_intel_x64_eapis() :
 }
 
 void
-exit_handler_intel_x64_eapis::resume()
+exit_handler_eapis::exit_handler::resume()
 {
     m_vmcs_eapis->resume();
 }
 
 void
-exit_handler_intel_x64_eapis::advance_and_resume()
+exit_handler_eapis::exit_handler::advance_and_resume()
 {
     this->advance_rip();
     m_vmcs_eapis->resume();
 }
 
 void
-exit_handler_intel_x64_eapis::handle_exit(vmcs::value_type reason)
+exit_handler_eapis::exit_handler::handle_exit(::intel_x64::vmcs::value_type reason)
 {
     switch (reason)
     {
-        case exit_reason::basic_exit_reason::monitor_trap_flag:
+        case exit_reason_basic::monitor_trap_flag:
             handle_exit__monitor_trap_flag();
             break;
 
-        case exit_reason::basic_exit_reason::io_instruction:
+        case exit_reason_basic::io_instruction:
             handle_exit__io_instruction();
             break;
 
-        case vmcs::exit_reason::basic_exit_reason::rdmsr:
+        case exit_reason_basic::rdmsr:
             handle_exit__rdmsr();
             break;
 
-        case vmcs::exit_reason::basic_exit_reason::wrmsr:
+        case exit_reason_basic::wrmsr:
             handle_exit__wrmsr();
             break;
 
-        case vmcs::exit_reason::basic_exit_reason::control_register_accesses:
+        case exit_reason_basic::control_register_accesses:
             handle_exit__ctl_reg_access();
             break;
 
         default:
-            exit_handler_intel_x64::handle_exit(reason);
+            bfvmm::intel_x64::exit_handler::handle_exit(reason);
             break;
     }
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall_registers(vmcall_registers_t &regs)
+exit_handler_eapis::exit_handler::handle_vmcall_registers(vmcall_registers_t &regs)
 {
     switch (regs.r02)
     {
@@ -118,12 +117,12 @@ exit_handler_intel_x64_eapis::handle_vmcall_registers(vmcall_registers_t &regs)
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall_data_string_json(
+exit_handler_eapis::exit_handler::handle_vmcall_data_string_json(
     const json &ijson, json &ojson)
 {
     m_json_commands.at(ijson.at("command"))(ijson, ojson);
 }
 
 void
-exit_handler_intel_x64_eapis::json_success(json &ojson)
+exit_handler_eapis::exit_handler::json_success(json &ojson)
 { ojson = {"success"}; }

--- a/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
@@ -24,7 +24,6 @@
 
 #include <intrinsics.h>
 
-namespace vmcs = ::intel_x64::vmcs;
 namespace reason = ::intel_x64::vmcs::exit_reason::basic_exit_reason;
 namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
@@ -58,7 +57,7 @@ exit_handler_eapis::exit_handler::advance_and_resume()
 }
 
 void
-exit_handler_eapis::exit_handler::handle_exit(vmcs::value_type reason)
+exit_handler_eapis::exit_handler::handle_exit(::intel_x64::vmcs::value_type reason)
 {
     switch (reason)
     {
@@ -80,6 +79,10 @@ exit_handler_eapis::exit_handler::handle_exit(vmcs::value_type reason)
 
         case reason::control_register_accesses:
             handle_exit__ctl_reg_access();
+            break;
+
+        case reason::cpuid:
+            handle_exit__cpuid();
             break;
 
         default:

--- a/src/hve/arch/intel_x64/exit_handler/io_instruction_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/io_instruction_emulation.cpp
@@ -24,32 +24,32 @@
 #include <arch/intel_x64/vmcs/32bit_control_fields.h>
 #include <arch/intel_x64/vmcs/natural_width_read_only_data_fields.h>
 
-using namespace intel_x64;
-using namespace vmcs;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void
-exit_handler_intel_x64_eapis::log_io_access(bool enable)
+exit_handler_eapis::exit_handler::log_io_access(bool enable)
 { m_io_access_log_enabled = enable; }
 
 void
-exit_handler_intel_x64_eapis::clear_io_access_log()
+exit_handler_eapis::exit_handler::clear_io_access_log()
 { m_io_access_log.clear(); }
 
 void
-exit_handler_intel_x64_eapis::trap_on_io_access_callback()
+exit_handler_eapis::exit_handler::trap_on_io_access_callback()
 {
-    primary_processor_based_vm_execution_controls::use_io_bitmaps::enable();
+    proc_ctls::use_io_bitmaps::enable();
     this->resume();
 }
 
 void
-exit_handler_intel_x64_eapis::handle_exit__io_instruction()
+exit_handler_eapis::exit_handler::handle_exit__io_instruction()
 {
-    register_monitor_trap(&exit_handler_intel_x64_eapis::trap_on_io_access_callback);
+    register_monitor_trap(&exit_handler_eapis::exit_handler::trap_on_io_access_callback);
 
     if (m_io_access_log_enabled)
-        m_io_access_log[exit_qualification::io_instruction::port_number::get()]++;
+        m_io_access_log[::intel_x64::vmcs::exit_qualification::io_instruction::port_number::get()]++;
 
-    primary_processor_based_vm_execution_controls::use_io_bitmaps::disable();
+    proc_ctls::use_io_bitmaps::disable();
     this->resume();
 }

--- a/src/hve/arch/intel_x64/exit_handler/io_instruction_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/io_instruction_emulation.cpp
@@ -24,8 +24,7 @@
 #include <arch/intel_x64/vmcs/32bit_control_fields.h>
 #include <arch/intel_x64/vmcs/natural_width_read_only_data_fields.h>
 
-namespace vmcs = ::intel_x64::vmcs;
-namespace proc_ctls = vmcs::primary_processor_based_vm_execution_controls;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
 namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void

--- a/src/hve/arch/intel_x64/exit_handler/io_instruction_vmcall.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/io_instruction_vmcall.cpp
@@ -27,12 +27,10 @@
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/verifiers.h"
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/io_instruction_verifiers.h"
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void
-exit_handler_intel_x64_eapis::register_json_vmcall__io_instruction()
+exit_handler_eapis::exit_handler::register_json_vmcall__io_instruction()
 {
     m_json_commands["enable_io_bitmaps"] = [&](const auto & ijson, auto & ojson)
     {
@@ -83,7 +81,7 @@ exit_handler_intel_x64_eapis::register_json_vmcall__io_instruction()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__io_instruction(
+exit_handler_eapis::exit_handler::handle_vmcall__io_instruction(
     vmcall_registers_t &regs)
 {
     switch (regs.r03)
@@ -118,7 +116,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__io_instruction(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__enable_io_bitmaps(
+exit_handler_eapis::exit_handler::handle_vmcall__enable_io_bitmaps(
     bool enabled)
 {
     if (policy(enable_io_bitmaps)->verify(enabled) != vmcall_verifier::allow)
@@ -137,7 +135,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__enable_io_bitmaps(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__trap_on_io_access(
+exit_handler_eapis::exit_handler::handle_vmcall__trap_on_io_access(
     port_type port)
 {
     if (policy(trap_on_io_access)->verify(port) != vmcall_verifier::allow)
@@ -148,7 +146,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__trap_on_io_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__trap_on_all_io_accesses()
+exit_handler_eapis::exit_handler::handle_vmcall__trap_on_all_io_accesses()
 {
     if (policy(trap_on_all_io_accesses)->verify() != vmcall_verifier::allow)
         policy(trap_on_all_io_accesses)->deny_vmcall();
@@ -158,7 +156,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__trap_on_all_io_accesses()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__pass_through_io_access(
+exit_handler_eapis::exit_handler::handle_vmcall__pass_through_io_access(
     port_type port)
 {
     if (policy(pass_through_io_access)->verify(port) != vmcall_verifier::allow)
@@ -169,7 +167,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__pass_through_io_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__pass_through_all_io_accesses()
+exit_handler_eapis::exit_handler::handle_vmcall__pass_through_all_io_accesses()
 {
     if (policy(pass_through_all_io_accesses)->verify() != vmcall_verifier::allow)
         policy(pass_through_all_io_accesses)->deny_vmcall();
@@ -179,7 +177,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__pass_through_all_io_accesses()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__whitelist_io_access(
+exit_handler_eapis::exit_handler::handle_vmcall__whitelist_io_access(
     const port_list_type &ports)
 {
     if (policy(whitelist_io_access)->verify(ports) != vmcall_verifier::allow)
@@ -193,7 +191,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__whitelist_io_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__blacklist_io_access(
+exit_handler_eapis::exit_handler::handle_vmcall__blacklist_io_access(
     const port_list_type &ports)
 {
     if (policy(blacklist_io_access)->verify(ports) != vmcall_verifier::allow)
@@ -207,7 +205,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__blacklist_io_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__log_io_access(
+exit_handler_eapis::exit_handler::handle_vmcall__log_io_access(
     bool enabled)
 {
     if (policy(log_io_access)->verify(enabled) != vmcall_verifier::allow)
@@ -218,7 +216,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__log_io_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__clear_io_access_log()
+exit_handler_eapis::exit_handler::handle_vmcall__clear_io_access_log()
 {
     if (policy(clear_io_access_log)->verify() != vmcall_verifier::allow)
         policy(clear_io_access_log)->deny_vmcall();
@@ -228,7 +226,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__clear_io_access_log()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__io_access_log(json &ojson)
+exit_handler_eapis::exit_handler::handle_vmcall__io_access_log(json &ojson)
 {
     if (policy(io_access_log)->verify() != vmcall_verifier::allow)
         policy(io_access_log)->deny_vmcall();

--- a/src/hve/arch/intel_x64/exit_handler/monitor_trap_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/monitor_trap_emulation.cpp
@@ -25,22 +25,21 @@
 #include <arch/intel_x64/vmcs/32bit_read_only_data_fields.h>
 #include <arch/intel_x64/vmcs/natural_width_read_only_data_fields.h>
 
-using namespace intel_x64;
-using namespace vmcs;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void
-exit_handler_intel_x64_eapis::clear_monitor_trap()
+exit_handler_eapis::exit_handler::clear_monitor_trap()
 {
-    primary_processor_based_vm_execution_controls::monitor_trap_flag::disable();
-    m_monitor_trap_callback = &exit_handler_intel_x64_eapis::unhandled_monitor_trap_callback;
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::monitor_trap_flag::disable();
+    m_monitor_trap_callback = &exit_handler_eapis::exit_handler::unhandled_monitor_trap_callback;
 }
 
 void
-exit_handler_intel_x64_eapis::unhandled_monitor_trap_callback()
+exit_handler_eapis::exit_handler::unhandled_monitor_trap_callback()
 { throw std::logic_error("unhandled_monitor_trap_callback called!!!"); }
 
 void
-exit_handler_intel_x64_eapis::handle_exit__monitor_trap_flag()
+exit_handler_eapis::exit_handler::handle_exit__monitor_trap_flag()
 {
     auto callback = m_monitor_trap_callback;
 

--- a/src/hve/arch/intel_x64/exit_handler/msr_vmcall.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/msr_vmcall.cpp
@@ -27,12 +27,10 @@
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/verifiers.h"
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/msr_verifiers.h"
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void
-exit_handler_intel_x64_eapis::register_json_vmcall__msr()
+exit_handler_eapis::exit_handler::register_json_vmcall__msr()
 {
     m_json_commands["enable_msr_bitmap"] = [&](const auto & ijson, auto & ojson) {
         this->handle_vmcall__enable_msr_bitmap(ijson.at("enabled"));
@@ -41,7 +39,7 @@ exit_handler_intel_x64_eapis::register_json_vmcall__msr()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__msr(
+exit_handler_eapis::exit_handler::handle_vmcall__msr(
     vmcall_registers_t &regs)
 {
     switch (regs.r03) {
@@ -59,7 +57,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__msr(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__enable_msr_bitmap(
+exit_handler_eapis::exit_handler::handle_vmcall__enable_msr_bitmap(
     bool enabled)
 {
     if (policy(enable_msr_bitmap)->verify(enabled) != vmcall_verifier::allow) {

--- a/src/hve/arch/intel_x64/exit_handler/policy.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/policy.cpp
@@ -28,8 +28,10 @@
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/wrmsr_verifiers.h"
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/cpuid_verifiers.h"
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 void
-exit_handler_intel_x64_eapis::init_policy()
+exit_handler_eapis::exit_handler::init_policy()
 {
     m_verifiers[vp::index_clear_denials] = std::make_unique<default_verifier__clear_denials>();
     m_verifiers[vp::index_dump_policy] = std::make_unique<default_verifier__dump_policy>();

--- a/src/hve/arch/intel_x64/exit_handler/rdmsr_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/rdmsr_emulation.cpp
@@ -21,16 +21,18 @@
 
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/exit_handler.h"
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 void
-exit_handler_intel_x64_eapis::log_rdmsr_access(bool enable)
+exit_handler_eapis::exit_handler::log_rdmsr_access(bool enable)
 { m_rdmsr_access_log_enabled = enable; }
 
 void
-exit_handler_intel_x64_eapis::clear_rdmsr_access_log()
+exit_handler_eapis::exit_handler::clear_rdmsr_access_log()
 { m_rdmsr_access_log.clear(); }
 
 void
-exit_handler_intel_x64_eapis::handle_exit__rdmsr()
+exit_handler_eapis::exit_handler::handle_exit__rdmsr()
 {
     if (m_rdmsr_access_log_enabled) {
         m_rdmsr_access_log[static_cast<msr_type>(m_state_save->rcx)]++;

--- a/src/hve/arch/intel_x64/exit_handler/rdmsr_vmcall.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/rdmsr_vmcall.cpp
@@ -27,12 +27,10 @@
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/verifiers.h"
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/rdmsr_verifiers.h"
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void
-exit_handler_intel_x64_eapis::register_json_vmcall__rdmsr()
+exit_handler_eapis::exit_handler::register_json_vmcall__rdmsr()
 {
     m_json_commands["trap_on_rdmsr_access"] = [&](const auto & ijson, auto & ojson) {
         this->handle_vmcall__trap_on_rdmsr_access(json_hex_or_dec<msr_type>(ijson, "msr"));
@@ -70,7 +68,7 @@ exit_handler_intel_x64_eapis::register_json_vmcall__rdmsr()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__rdmsr(
+exit_handler_eapis::exit_handler::handle_vmcall__rdmsr(
     vmcall_registers_t &regs)
 {
     switch (regs.r03) {
@@ -96,7 +94,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__rdmsr(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__trap_on_rdmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__trap_on_rdmsr_access(
     msr_type msr)
 {
     if (policy(trap_on_rdmsr_access)->verify(msr) != vmcall_verifier::allow) {
@@ -108,7 +106,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__trap_on_rdmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__trap_on_all_rdmsr_accesses()
+exit_handler_eapis::exit_handler::handle_vmcall__trap_on_all_rdmsr_accesses()
 {
     if (policy(trap_on_all_rdmsr_accesses)->verify() != vmcall_verifier::allow) {
         policy(trap_on_all_rdmsr_accesses)->deny_vmcall();
@@ -119,7 +117,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__trap_on_all_rdmsr_accesses()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__pass_through_rdmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__pass_through_rdmsr_access(
     msr_type msr)
 {
     if (policy(pass_through_rdmsr_access)->verify(msr) != vmcall_verifier::allow) {
@@ -131,7 +129,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__pass_through_rdmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__pass_through_all_rdmsr_accesses()
+exit_handler_eapis::exit_handler::handle_vmcall__pass_through_all_rdmsr_accesses()
 {
     if (policy(pass_through_all_rdmsr_accesses)->verify() != vmcall_verifier::allow) {
         policy(pass_through_all_rdmsr_accesses)->deny_vmcall();
@@ -142,7 +140,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__pass_through_all_rdmsr_accesses()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__whitelist_rdmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__whitelist_rdmsr_access(
     msr_list_type msrs)
 {
     if (policy(whitelist_rdmsr_access)->verify(msrs) != vmcall_verifier::allow) {
@@ -158,7 +156,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__whitelist_rdmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__blacklist_rdmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__blacklist_rdmsr_access(
     msr_list_type msrs)
 {
     if (policy(blacklist_rdmsr_access)->verify(msrs) != vmcall_verifier::allow) {
@@ -174,7 +172,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__blacklist_rdmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__log_rdmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__log_rdmsr_access(
     bool enabled)
 {
     if (policy(log_rdmsr_access)->verify(enabled) != vmcall_verifier::allow) {
@@ -186,7 +184,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__log_rdmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__clear_rdmsr_access_log()
+exit_handler_eapis::exit_handler::handle_vmcall__clear_rdmsr_access_log()
 {
     if (policy(clear_rdmsr_access_log)->verify() != vmcall_verifier::allow) {
         policy(clear_rdmsr_access_log)->deny_vmcall();
@@ -197,7 +195,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__clear_rdmsr_access_log()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__rdmsr_access_log(
+exit_handler_eapis::exit_handler::handle_vmcall__rdmsr_access_log(
     json &ojson)
 {
     if (policy(rdmsr_access_log)->verify() != vmcall_verifier::allow) {

--- a/src/hve/arch/intel_x64/exit_handler/verifiers_vmcall.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/verifiers_vmcall.cpp
@@ -23,11 +23,10 @@
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/verifiers.h"
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/vmcall_interface.h"
 
-using namespace x64;
-using namespace intel_x64;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void
-exit_handler_intel_x64_eapis::register_json_vmcall__verifiers()
+exit_handler_eapis::exit_handler::register_json_vmcall__verifiers()
 {
     m_json_commands["clear_denials"] = [&](const auto &, auto & ojson) {
         this->handle_vmcall__clear_denials();
@@ -48,7 +47,7 @@ std::string get_typename(const T &t)
 { return typeid(t).name(); }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__clear_denials()
+exit_handler_eapis::exit_handler::handle_vmcall__clear_denials()
 {
     if (policy(clear_denials)->verify() != vmcall_verifier::allow) {
         policy(clear_denials)->deny_vmcall();
@@ -59,7 +58,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__clear_denials()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__dump_policy(json &ojson)
+exit_handler_eapis::exit_handler::handle_vmcall__dump_policy(json &ojson)
 {
     if (policy(dump_policy)->verify() != vmcall_verifier::allow) {
         policy(dump_policy)->deny_vmcall();
@@ -73,7 +72,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__dump_policy(json &ojson)
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__dump_denials(json &ojson)
+exit_handler_eapis::exit_handler::handle_vmcall__dump_denials(json &ojson)
 {
     if (policy(dump_denials)->verify() != vmcall_verifier::allow) {
         policy(dump_denials)->deny_vmcall();

--- a/src/hve/arch/intel_x64/exit_handler/vpid_vmcall.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/vpid_vmcall.cpp
@@ -25,12 +25,10 @@
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/verifiers.h"
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/vpid_verifiers.h"
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void
-exit_handler_intel_x64_eapis::register_json_vmcall__vpid()
+exit_handler_eapis::exit_handler::register_json_vmcall__vpid()
 {
     m_json_commands["enable_vpid"] = [&](const auto & ijson, auto & ojson) {
         this->handle_vmcall__enable_vpid(ijson.at("enabled"));
@@ -39,7 +37,7 @@ exit_handler_intel_x64_eapis::register_json_vmcall__vpid()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__vpid(
+exit_handler_eapis::exit_handler::handle_vmcall__vpid(
     vmcall_registers_t &regs)
 {
     switch (regs.r03) {
@@ -57,7 +55,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__vpid(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__enable_vpid(bool enabled)
+exit_handler_eapis::exit_handler::handle_vmcall__enable_vpid(bool enabled)
 {
     if (policy(enable_vpid)->verify(enabled) != vmcall_verifier::allow) {
         policy(enable_vpid)->deny_vmcall();

--- a/src/hve/arch/intel_x64/exit_handler/wrmsr_emulation.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/wrmsr_emulation.cpp
@@ -21,16 +21,18 @@
 
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/exit_handler.h"
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 void
-exit_handler_intel_x64_eapis::log_wrmsr_access(bool enable)
+exit_handler_eapis::exit_handler::log_wrmsr_access(bool enable)
 { m_wrmsr_access_log_enabled = enable; }
 
 void
-exit_handler_intel_x64_eapis::clear_wrmsr_access_log()
+exit_handler_eapis::exit_handler::clear_wrmsr_access_log()
 { m_wrmsr_access_log.clear(); }
 
 void
-exit_handler_intel_x64_eapis::handle_exit__wrmsr()
+exit_handler_eapis::exit_handler::handle_exit__wrmsr()
 {
     if (m_wrmsr_access_log_enabled) {
         m_wrmsr_access_log[static_cast<msr_type>(m_state_save->rcx)]++;

--- a/src/hve/arch/intel_x64/exit_handler/wrmsr_vmcall.cpp
+++ b/src/hve/arch/intel_x64/exit_handler/wrmsr_vmcall.cpp
@@ -27,12 +27,10 @@
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/verifiers.h"
 #include "../../../../../include/hve/arch/intel_x64/exit_handler/wrmsr_verifiers.h"
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 void
-exit_handler_intel_x64_eapis::register_json_vmcall__wrmsr()
+exit_handler_eapis::exit_handler::register_json_vmcall__wrmsr()
 {
     m_json_commands["trap_on_wrmsr_access"] = [&](const auto & ijson, auto & ojson) {
         this->handle_vmcall__trap_on_wrmsr_access(json_hex_or_dec<msr_type>(ijson, "msr"));
@@ -70,7 +68,7 @@ exit_handler_intel_x64_eapis::register_json_vmcall__wrmsr()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__wrmsr(
+exit_handler_eapis::exit_handler::handle_vmcall__wrmsr(
     vmcall_registers_t &regs)
 {
     switch (regs.r03) {
@@ -96,7 +94,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__wrmsr(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__trap_on_wrmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__trap_on_wrmsr_access(
     msr_type msr)
 {
     if (policy(trap_on_wrmsr_access)->verify(msr) != vmcall_verifier::allow) {
@@ -108,7 +106,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__trap_on_wrmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__trap_on_all_wrmsr_accesses()
+exit_handler_eapis::exit_handler::handle_vmcall__trap_on_all_wrmsr_accesses()
 {
     if (policy(trap_on_all_wrmsr_accesses)->verify() != vmcall_verifier::allow) {
         policy(trap_on_all_wrmsr_accesses)->deny_vmcall();
@@ -119,7 +117,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__trap_on_all_wrmsr_accesses()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__pass_through_wrmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__pass_through_wrmsr_access(
     msr_type msr)
 {
     if (policy(pass_through_wrmsr_access)->verify(msr) != vmcall_verifier::allow) {
@@ -131,7 +129,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__pass_through_wrmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__pass_through_all_wrmsr_accesses()
+exit_handler_eapis::exit_handler::handle_vmcall__pass_through_all_wrmsr_accesses()
 {
     if (policy(pass_through_all_wrmsr_accesses)->verify() != vmcall_verifier::allow) {
         policy(pass_through_all_wrmsr_accesses)->deny_vmcall();
@@ -142,7 +140,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__pass_through_all_wrmsr_accesses()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__whitelist_wrmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__whitelist_wrmsr_access(
     msr_list_type msrs)
 {
     if (policy(whitelist_wrmsr_access)->verify(msrs) != vmcall_verifier::allow) {
@@ -158,7 +156,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__whitelist_wrmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__blacklist_wrmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__blacklist_wrmsr_access(
     msr_list_type msrs)
 {
     if (policy(blacklist_wrmsr_access)->verify(msrs) != vmcall_verifier::allow) {
@@ -174,7 +172,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__blacklist_wrmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__log_wrmsr_access(
+exit_handler_eapis::exit_handler::handle_vmcall__log_wrmsr_access(
     bool enabled)
 {
     if (policy(log_wrmsr_access)->verify(enabled) != vmcall_verifier::allow) {
@@ -186,7 +184,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__log_wrmsr_access(
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__clear_wrmsr_access_log()
+exit_handler_eapis::exit_handler::handle_vmcall__clear_wrmsr_access_log()
 {
     if (policy(clear_wrmsr_access_log)->verify() != vmcall_verifier::allow) {
         policy(clear_wrmsr_access_log)->deny_vmcall();
@@ -197,7 +195,7 @@ exit_handler_intel_x64_eapis::handle_vmcall__clear_wrmsr_access_log()
 }
 
 void
-exit_handler_intel_x64_eapis::handle_vmcall__wrmsr_access_log(
+exit_handler_eapis::exit_handler::handle_vmcall__wrmsr_access_log(
     json &ojson)
 {
     if (policy(wrmsr_access_log)->verify() != vmcall_verifier::allow) {

--- a/src/hve/arch/intel_x64/vmcs/apic.cpp
+++ b/src/hve/arch/intel_x64/vmcs/apic.cpp
@@ -24,280 +24,279 @@
 
 #include "../../../../../include/hve/arch/intel_x64/vmcs/apic.h"
 
-using namespace x64;
-using namespace intel_x64;
+namespace intel = eapis::hve::intel_x64;
 
-apic_intel_x64::apic_intel_x64()
+intel::apic::apic()
 {
     // bfdebug << intel_x64::msrs::ia32_x2apic_apicid::get() << bfendl;
 }
 
 uint32_t
-apic_intel_x64::id() const
+intel::apic::id() const
 { return m_vapic_page.at(0x020); }
 
 void
-apic_intel_x64::set_id(uint32_t val)
+intel::apic::set_id(uint32_t val)
 { m_vapic_page.at(0x020) = val; }
 
 uint32_t
-apic_intel_x64::version() const
+intel::apic::version() const
 { return m_vapic_page.at(0x030); }
 
 void
-apic_intel_x64::set_version(uint32_t val)
+intel::apic::set_version(uint32_t val)
 { m_vapic_page.at(0x030) = val; }
 
 uint32_t
-apic_intel_x64::task_priority() const
+intel::apic::task_priority() const
 { return m_vapic_page.at(0x080); }
 
 void
-apic_intel_x64::set_task_priority(uint32_t val)
+intel::apic::set_task_priority(uint32_t val)
 { m_vapic_page.at(0x080) = val; }
 
 uint32_t
-apic_intel_x64::processor_priority() const
+intel::apic::processor_priority() const
 { return m_vapic_page.at(0x0A0); }
 
 void
-apic_intel_x64::set_processor_priority(uint32_t val)
+intel::apic::set_processor_priority(uint32_t val)
 { m_vapic_page.at(0x0A0) = val; }
 
 uint32_t
-apic_intel_x64::end_of_interrupt() const
+intel::apic::end_of_interrupt() const
 { return m_vapic_page.at(0x0B0); }
 
 void
-apic_intel_x64::set_end_of_interrupt(uint32_t val)
+intel::apic::set_end_of_interrupt(uint32_t val)
 { m_vapic_page.at(0x0B0) = val; }
 
 uint32_t
-apic_intel_x64::logical_destination() const
+intel::apic::logical_destination() const
 { return m_vapic_page.at(0x0D0); }
 
 void
-apic_intel_x64::set_logical_destination(uint32_t val)
+intel::apic::set_logical_destination(uint32_t val)
 { m_vapic_page.at(0x0D0) = val; }
 
 uint32_t
-apic_intel_x64::spurious_interrupt_vector() const
+intel::apic::spurious_interrupt_vector() const
 { return m_vapic_page.at(0x0F0); }
 
 void
-apic_intel_x64::set_spurious_interrupt_vector(uint32_t val)
+intel::apic::set_spurious_interrupt_vector(uint32_t val)
 { m_vapic_page.at(0x0F0) = val; }
 
 uint32_t
-apic_intel_x64::in_service_031_000() const
+intel::apic::in_service_031_000() const
 { return m_vapic_page.at(0x100); }
 
 void
-apic_intel_x64::set_in_service_031_000(uint32_t val)
+intel::apic::set_in_service_031_000(uint32_t val)
 { m_vapic_page.at(0x100) = val; }
 
 uint32_t
-apic_intel_x64::in_service_063_032() const
+intel::apic::in_service_063_032() const
 { return m_vapic_page.at(0x110); }
 
 void
-apic_intel_x64::set_in_service_063_032(uint32_t val)
+intel::apic::set_in_service_063_032(uint32_t val)
 { m_vapic_page.at(0x110) = val; }
 
 uint32_t
-apic_intel_x64::in_service_095_064() const
+intel::apic::in_service_095_064() const
 { return m_vapic_page.at(0x120); }
 
 void
-apic_intel_x64::set_in_service_095_064(uint32_t val)
+intel::apic::set_in_service_095_064(uint32_t val)
 { m_vapic_page.at(0x120) = val; }
 
 uint32_t
-apic_intel_x64::in_service_127_096() const
+intel::apic::in_service_127_096() const
 { return m_vapic_page.at(0x130); }
 
 void
-apic_intel_x64::set_in_service_127_096(uint32_t val)
+intel::apic::set_in_service_127_096(uint32_t val)
 { m_vapic_page.at(0x130) = val; }
 
 uint32_t
-apic_intel_x64::in_service_159_128() const
+intel::apic::in_service_159_128() const
 { return m_vapic_page.at(0x140); }
 
 void
-apic_intel_x64::set_in_service_159_128(uint32_t val)
+intel::apic::set_in_service_159_128(uint32_t val)
 { m_vapic_page.at(0x140) = val; }
 
 uint32_t
-apic_intel_x64::in_service_191_160() const
+intel::apic::in_service_191_160() const
 { return m_vapic_page.at(0x150); }
 
 void
-apic_intel_x64::set_in_service_191_160(uint32_t val)
+intel::apic::set_in_service_191_160(uint32_t val)
 { m_vapic_page.at(0x150) = val; }
 
 uint32_t
-apic_intel_x64::in_service_223_192() const
+intel::apic::in_service_223_192() const
 { return m_vapic_page.at(0x160); }
 
 void
-apic_intel_x64::set_in_service_223_192(uint32_t val)
+intel::apic::set_in_service_223_192(uint32_t val)
 { m_vapic_page.at(0x160) = val; }
 
 uint32_t
-apic_intel_x64::in_service_255_224() const
+intel::apic::in_service_255_224() const
 { return m_vapic_page.at(0x170); }
 
 void
-apic_intel_x64::set_in_service_255_224(uint32_t val)
+intel::apic::set_in_service_255_224(uint32_t val)
 { m_vapic_page.at(0x170) = val; }
 
 uint32_t
-apic_intel_x64::trigger_mode_031_000() const
+intel::apic::trigger_mode_031_000() const
 { return m_vapic_page.at(0x180); }
 
 void
-apic_intel_x64::set_trigger_mode_031_000(uint32_t val)
+intel::apic::set_trigger_mode_031_000(uint32_t val)
 { m_vapic_page.at(0x180) = val; }
 
 uint32_t
-apic_intel_x64::trigger_mode_063_032() const
+intel::apic::trigger_mode_063_032() const
 { return m_vapic_page.at(0x190); }
 
 void
-apic_intel_x64::set_trigger_mode_063_032(uint32_t val)
+intel::apic::set_trigger_mode_063_032(uint32_t val)
 { m_vapic_page.at(0x190) = val; }
 
 uint32_t
-apic_intel_x64::trigger_mode_095_064() const
+intel::apic::trigger_mode_095_064() const
 { return m_vapic_page.at(0x1A0); }
 
 void
-apic_intel_x64::set_trigger_mode_095_064(uint32_t val)
+intel::apic::set_trigger_mode_095_064(uint32_t val)
 { m_vapic_page.at(0x1A0) = val; }
 
 uint32_t
-apic_intel_x64::trigger_mode_127_096() const
+intel::apic::trigger_mode_127_096() const
 { return m_vapic_page.at(0x1B0); }
 
 void
-apic_intel_x64::set_trigger_mode_127_096(uint32_t val)
+intel::apic::set_trigger_mode_127_096(uint32_t val)
 { m_vapic_page.at(0x1B0) = val; }
 
 uint32_t
-apic_intel_x64::trigger_mode_159_128() const
+intel::apic::trigger_mode_159_128() const
 { return m_vapic_page.at(0x1C0); }
 
 void
-apic_intel_x64::set_trigger_mode_159_128(uint32_t val)
+intel::apic::set_trigger_mode_159_128(uint32_t val)
 { m_vapic_page.at(0x1C0) = val; }
 
 uint32_t
-apic_intel_x64::trigger_mode_191_160() const
+intel::apic::trigger_mode_191_160() const
 { return m_vapic_page.at(0x1D0); }
 
 void
-apic_intel_x64::set_trigger_mode_191_160(uint32_t val)
+intel::apic::set_trigger_mode_191_160(uint32_t val)
 { m_vapic_page.at(0x1D0) = val; }
 
 uint32_t
-apic_intel_x64::trigger_mode_223_192() const
+intel::apic::trigger_mode_223_192() const
 { return m_vapic_page.at(0x1E0); }
 
 void
-apic_intel_x64::set_trigger_mode_223_192(uint32_t val)
+intel::apic::set_trigger_mode_223_192(uint32_t val)
 { m_vapic_page.at(0x1E0) = val; }
 
 uint32_t
-apic_intel_x64::trigger_mode_255_224() const
+intel::apic::trigger_mode_255_224() const
 { return m_vapic_page.at(0x1F0); }
 
 void
-apic_intel_x64::set_trigger_mode_255_224(uint32_t val)
+intel::apic::set_trigger_mode_255_224(uint32_t val)
 { m_vapic_page.at(0x1F0) = val; }
 
 uint32_t
-apic_intel_x64::interrupt_request_031_000() const
+intel::apic::interrupt_request_031_000() const
 { return m_vapic_page.at(0x200); }
 
 void
-apic_intel_x64::set_interrupt_request_031_000(uint32_t val)
+intel::apic::set_interrupt_request_031_000(uint32_t val)
 { m_vapic_page.at(0x200) = val; }
 
 uint32_t
-apic_intel_x64::interrupt_request_063_032() const
+intel::apic::interrupt_request_063_032() const
 { return m_vapic_page.at(0x210); }
 
 void
-apic_intel_x64::set_interrupt_request_063_032(uint32_t val)
+intel::apic::set_interrupt_request_063_032(uint32_t val)
 { m_vapic_page.at(0x210) = val; }
 
 uint32_t
-apic_intel_x64::interrupt_request_095_064() const
+intel::apic::interrupt_request_095_064() const
 { return m_vapic_page.at(0x220); }
 
 void
-apic_intel_x64::set_interrupt_request_095_064(uint32_t val)
+intel::apic::set_interrupt_request_095_064(uint32_t val)
 { m_vapic_page.at(0x220) = val; }
 
 uint32_t
-apic_intel_x64::interrupt_request_127_096() const
+intel::apic::interrupt_request_127_096() const
 { return m_vapic_page.at(0x230); }
 
 void
-apic_intel_x64::set_interrupt_request_127_096(uint32_t val)
+intel::apic::set_interrupt_request_127_096(uint32_t val)
 { m_vapic_page.at(0x230) = val; }
 
 uint32_t
-apic_intel_x64::interrupt_request_159_128() const
+intel::apic::interrupt_request_159_128() const
 { return m_vapic_page.at(0x240); }
 
 void
-apic_intel_x64::set_interrupt_request_159_128(uint32_t val)
+intel::apic::set_interrupt_request_159_128(uint32_t val)
 { m_vapic_page.at(0x240) = val; }
 
 uint32_t
-apic_intel_x64::interrupt_request_191_160() const
+intel::apic::interrupt_request_191_160() const
 { return m_vapic_page.at(0x250); }
 
 void
-apic_intel_x64::set_interrupt_request_191_160(uint32_t val)
+intel::apic::set_interrupt_request_191_160(uint32_t val)
 { m_vapic_page.at(0x250) = val; }
 
 uint32_t
-apic_intel_x64::interrupt_request_223_192() const
+intel::apic::interrupt_request_223_192() const
 { return m_vapic_page.at(0x260); }
 
 void
-apic_intel_x64::set_interrupt_request_223_192(uint32_t val)
+intel::apic::set_interrupt_request_223_192(uint32_t val)
 { m_vapic_page.at(0x260) = val; }
 
 uint32_t
-apic_intel_x64::interrupt_request_255_224() const
+intel::apic::interrupt_request_255_224() const
 { return m_vapic_page.at(0x270); }
 
 void
-apic_intel_x64::set_interrupt_request_255_224(uint32_t val)
+intel::apic::set_interrupt_request_255_224(uint32_t val)
 { m_vapic_page.at(0x270) = val; }
 
 uint32_t
-apic_intel_x64::error_status() const
+intel::apic::error_status() const
 { return m_vapic_page.at(0x280); }
 
 void
-apic_intel_x64::set_error_status(uint32_t val)
+intel::apic::set_error_status(uint32_t val)
 { m_vapic_page.at(0x280) = val; }
 
 uint32_t
-apic_intel_x64::lvt_cmci() const
+intel::apic::lvt_cmci() const
 { return m_vapic_page.at(0x2F0); }
 
 void
-apic_intel_x64::set_lvt_cmci(uint32_t val)
+intel::apic::set_lvt_cmci(uint32_t val)
 { m_vapic_page.at(0x2F0) = val; }
 
 uint64_t
-apic_intel_x64::interrupt_command() const
+intel::apic::interrupt_command() const
 {
     uint64_t lower = m_vapic_page.at(0x300);
     uint64_t upper = m_vapic_page.at(0x310);
@@ -306,7 +305,7 @@ apic_intel_x64::interrupt_command() const
 }
 
 void
-apic_intel_x64::set_interrupt_command(uint64_t val)
+intel::apic::set_interrupt_command(uint64_t val)
 {
     auto lower = gsl::narrow_cast<uint32_t>((val & 0x00000000FFFFFFFF));
     auto upper = gsl::narrow_cast<uint32_t>((val & 0xFFFFFFFF00000000) >> 32);
@@ -316,73 +315,73 @@ apic_intel_x64::set_interrupt_command(uint64_t val)
 }
 
 uint32_t
-apic_intel_x64::lvt_timer() const
+intel::apic::lvt_timer() const
 { return m_vapic_page.at(0x320); }
 
 void
-apic_intel_x64::set_lvt_timer(uint32_t val)
+intel::apic::set_lvt_timer(uint32_t val)
 { m_vapic_page.at(0x320) = val; }
 
 uint32_t
-apic_intel_x64::lvt_thermal_sensor() const
+intel::apic::lvt_thermal_sensor() const
 { return m_vapic_page.at(0x330); }
 
 void
-apic_intel_x64::set_lvt_thermal_sensor(uint32_t val)
+intel::apic::set_lvt_thermal_sensor(uint32_t val)
 { m_vapic_page.at(0x330) = val; }
 
 uint32_t
-apic_intel_x64::lvt_performance_monitoring() const
+intel::apic::lvt_performance_monitoring() const
 { return m_vapic_page.at(0x340); }
 
 void
-apic_intel_x64::set_lvt_performance_monitoring(uint32_t val)
+intel::apic::set_lvt_performance_monitoring(uint32_t val)
 { m_vapic_page.at(0x340) = val; }
 
 uint32_t
-apic_intel_x64::lvt_lint0() const
+intel::apic::lvt_lint0() const
 { return m_vapic_page.at(0x350); }
 
 void
-apic_intel_x64::set_lvt_lint0(uint32_t val)
+intel::apic::set_lvt_lint0(uint32_t val)
 { m_vapic_page.at(0x350) = val; }
 
 uint32_t
-apic_intel_x64::lvt_lint1() const
+intel::apic::lvt_lint1() const
 { return m_vapic_page.at(0x360); }
 
 void
-apic_intel_x64::set_lvt_lint1(uint32_t val)
+intel::apic::set_lvt_lint1(uint32_t val)
 { m_vapic_page.at(0x360) = val; }
 
 uint32_t
-apic_intel_x64::lvt_error() const
+intel::apic::lvt_error() const
 { return m_vapic_page.at(0x370); }
 
 void
-apic_intel_x64::set_lvt_error(uint32_t val)
+intel::apic::set_lvt_error(uint32_t val)
 { m_vapic_page.at(0x370) = val; }
 
 uint32_t
-apic_intel_x64::initial_count() const
+intel::apic::initial_count() const
 { return m_vapic_page.at(0x380); }
 
 void
-apic_intel_x64::set_initial_count(uint32_t val)
+intel::apic::set_initial_count(uint32_t val)
 { m_vapic_page.at(0x380) = val; }
 
 uint32_t
-apic_intel_x64::current_count() const
+intel::apic::current_count() const
 { return m_vapic_page.at(0x390); }
 
 void
-apic_intel_x64::set_current_count(uint32_t val)
+intel::apic::set_current_count(uint32_t val)
 { m_vapic_page.at(0x390) = val; }
 
 uint32_t
-apic_intel_x64::divide_configuration() const
+intel::apic::divide_configuration() const
 { return m_vapic_page.at(0x3E0); }
 
 void
-apic_intel_x64::set_divide_configuration(uint32_t val)
+intel::apic::set_divide_configuration(uint32_t val)
 { m_vapic_page.at(0x3E0) = val; }

--- a/src/hve/arch/intel_x64/vmcs/ept_entry.cpp
+++ b/src/hve/arch/intel_x64/vmcs/ept_entry.cpp
@@ -23,118 +23,119 @@
 #include "../../../../../include/hve/arch/intel_x64/vmcs/ept_entry.h"
 
 #include <arch/x64/misc.h>
-using namespace x64;
 
-ept_entry_intel_x64::ept_entry_intel_x64(gsl::not_null<pointer> pte) noexcept :
+namespace intel = eapis::hve::intel_x64;
+
+intel::ept_entry::ept_entry(gsl::not_null<pointer> pte) noexcept :
     m_epte(pte.get())
 { }
 
-ept_entry_intel_x64::pointer
-ept_entry_intel_x64::epte() const noexcept
+intel::ept_entry::pointer
+intel::ept_entry::epte() const noexcept
 { return m_epte; }
 
 void
-ept_entry_intel_x64::set_epte(pointer val) noexcept
+intel::ept_entry::set_epte(pointer val) noexcept
 { m_epte = val; }
 
-ept_entry_intel_x64::epte_value
-ept_entry_intel_x64::epte_val() const noexcept
+intel::ept_entry::epte_value
+intel::ept_entry::epte_val() const noexcept
 { return *m_epte; }
 
 void
-ept_entry_intel_x64::set_epte_val(epte_value val) noexcept
+intel::ept_entry::set_epte_val(epte_value val) noexcept
 { *m_epte = val; }
 
 bool
-ept_entry_intel_x64::read_access() const noexcept
+intel::ept_entry::read_access() const noexcept
 { return is_bit_set(*m_epte, 0); }
 
 void
-ept_entry_intel_x64::set_read_access(bool enabled) noexcept
+intel::ept_entry::set_read_access(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 0) : clear_bit(*m_epte, 0); }
 
 bool
-ept_entry_intel_x64::write_access() const noexcept
+intel::ept_entry::write_access() const noexcept
 { return is_bit_set(*m_epte, 1); }
 
 void
-ept_entry_intel_x64::set_write_access(bool enabled) noexcept
+intel::ept_entry::set_write_access(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 1) : clear_bit(*m_epte, 1); }
 
 bool
-ept_entry_intel_x64::execute_access() const noexcept
+intel::ept_entry::execute_access() const noexcept
 { return is_bit_set(*m_epte, 2); }
 
 void
-ept_entry_intel_x64::set_execute_access(bool enabled) noexcept
+intel::ept_entry::set_execute_access(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 2) : clear_bit(*m_epte, 2); }
 
-ept_entry_intel_x64::memory_type_type
-ept_entry_intel_x64::memory_type() const noexcept
+intel::ept_entry::memory_type_type
+intel::ept_entry::memory_type() const noexcept
 { return get_bits(*m_epte, 0x0000000000000038UL) >> 3; }
 
 void
-ept_entry_intel_x64::set_memory_type(memory_type_type val) noexcept
+intel::ept_entry::set_memory_type(memory_type_type val) noexcept
 { *m_epte = set_bits(*m_epte, 0x0000000000000038UL, val << 3); }
 
 bool
-ept_entry_intel_x64::ignore_pat() const noexcept
+intel::ept_entry::ignore_pat() const noexcept
 { return is_bit_set(*m_epte, 6); }
 
 void
-ept_entry_intel_x64::set_ignore_pat(bool enabled) noexcept
+intel::ept_entry::set_ignore_pat(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 6) : clear_bit(*m_epte, 6); }
 
 bool
-ept_entry_intel_x64::entry_type() const noexcept
+intel::ept_entry::entry_type() const noexcept
 { return is_bit_set(*m_epte, 7); }
 
 void
-ept_entry_intel_x64::set_entry_type(bool enabled) noexcept
+intel::ept_entry::set_entry_type(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 7) : clear_bit(*m_epte, 7); }
 
 bool
-ept_entry_intel_x64::accessed() const noexcept
+intel::ept_entry::accessed() const noexcept
 { return is_bit_set(*m_epte, 8); }
 
 void
-ept_entry_intel_x64::set_accessed(bool enabled) noexcept
+intel::ept_entry::set_accessed(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 8) : clear_bit(*m_epte, 8); }
 
 bool
-ept_entry_intel_x64::dirty() const noexcept
+intel::ept_entry::dirty() const noexcept
 { return is_bit_set(*m_epte, 9); }
 
 void
-ept_entry_intel_x64::set_dirty(bool enabled) noexcept
+intel::ept_entry::set_dirty(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 9) : clear_bit(*m_epte, 9); }
 
 bool
-ept_entry_intel_x64::execute_access_user() const noexcept
+intel::ept_entry::execute_access_user() const noexcept
 { return is_bit_set(*m_epte, 10); }
 
 void
-ept_entry_intel_x64::set_execute_access_user(bool enabled) noexcept
+intel::ept_entry::set_execute_access_user(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 10) : clear_bit(*m_epte, 10); }
 
-ept_entry_intel_x64::integer_pointer
-ept_entry_intel_x64::phys_addr() const noexcept
+intel::ept_entry::integer_pointer
+intel::ept_entry::phys_addr() const noexcept
 { return get_bits(*m_epte, 0x0000FFFFFFFFF000UL); }
 
 void
-ept_entry_intel_x64::set_phys_addr(integer_pointer addr) noexcept
+intel::ept_entry::set_phys_addr(integer_pointer addr) noexcept
 { *m_epte = set_bits(*m_epte, 0x0000FFFFFFFFF000UL, addr); }
 
 bool
-ept_entry_intel_x64::suppress_ve() const noexcept
+intel::ept_entry::suppress_ve() const noexcept
 { return is_bit_set(*m_epte, 63); }
 
 void
-ept_entry_intel_x64::set_suppress_ve(bool enabled) noexcept
+intel::ept_entry::set_suppress_ve(bool enabled) noexcept
 { *m_epte = enabled ? set_bit(*m_epte, 63) : clear_bit(*m_epte, 63); }
 
 void
-ept_entry_intel_x64::trap_on_access() noexcept
+intel::ept_entry::trap_on_access() noexcept
 {
     this->set_read_access(false);
     this->set_write_access(false);
@@ -142,7 +143,7 @@ ept_entry_intel_x64::trap_on_access() noexcept
 }
 
 void
-ept_entry_intel_x64::pass_through_access() noexcept
+intel::ept_entry::pass_through_access() noexcept
 {
     this->set_read_access(true);
     this->set_write_access(true);
@@ -150,5 +151,5 @@ ept_entry_intel_x64::pass_through_access() noexcept
 }
 
 void
-ept_entry_intel_x64::clear() noexcept
+intel::ept_entry::clear() noexcept
 { *m_epte = 0; }

--- a/src/hve/arch/intel_x64/vmcs/root_ept.cpp
+++ b/src/hve/arch/intel_x64/vmcs/root_ept.cpp
@@ -23,119 +23,119 @@
 #include "../../../../../include/hve/arch/intel_x64/vmcs/root_ept.h"
 #include <bfvmm/memory_manager/memory_manager_x64.h>
 
-using namespace intel_x64;
+namespace intel = eapis::hve::intel_x64;
 
 // -----------------------------------------------------------------------------
 // Implementation
 // -----------------------------------------------------------------------------
 
-root_ept_intel_x64::root_ept_intel_x64() :
-    m_ept{std::make_unique<ept_intel_x64>(&m_eptp)}
+intel::root_ept::root_ept() :
+    m_ept{std::make_unique<ept>(&m_eptp)}
 { }
 
-root_ept_intel_x64::eptp_type
-root_ept_intel_x64::eptp()
+intel::root_ept::eptp_type
+intel::root_ept::eptp()
 { return m_eptp; }
 
 void
-root_ept_intel_x64::unmap(integer_pointer gpa) noexcept
+intel::root_ept::unmap(integer_pointer gpa) noexcept
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     unmap_page(gpa);
 }
 
 void
-root_ept_intel_x64::setup_identity_map_1g(
+intel::root_ept::setup_identity_map_1g(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pdpt::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pdpt::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pdpt::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pdpt::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pdpt::size_bytes)
-        this->map_1g(gpa, gpa, ept::memory_attr::pt_wb);
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pdpt::size_bytes)
+        this->map_1g(gpa, gpa, ::intel_x64::ept::memory_attr::pt_wb);
 }
 
 void
-root_ept_intel_x64::setup_identity_map_2m(
+intel::root_ept::setup_identity_map_2m(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pd::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pd::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pd::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pd::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pd::size_bytes)
-        this->map_2m(gpa, gpa, ept::memory_attr::pt_wb);
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pd::size_bytes)
+        this->map_2m(gpa, gpa, ::intel_x64::ept::memory_attr::pt_wb);
 }
 
 void
-root_ept_intel_x64::setup_identity_map_4k(
+intel::root_ept::setup_identity_map_4k(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pt::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pt::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pt::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pt::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pt::size_bytes)
-        this->map_4k(gpa, gpa, ept::memory_attr::pt_wb);
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pt::size_bytes)
+        this->map_4k(gpa, gpa, ::intel_x64::ept::memory_attr::pt_wb);
 }
 
 void
-root_ept_intel_x64::unmap_identity_map_1g(
+intel::root_ept::unmap_identity_map_1g(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pdpt::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pdpt::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pdpt::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pdpt::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pdpt::size_bytes)
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pdpt::size_bytes)
         this->unmap(gpa);
 }
 
 void
-root_ept_intel_x64::unmap_identity_map_2m(
+intel::root_ept::unmap_identity_map_2m(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pd::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pd::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pd::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pd::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pd::size_bytes)
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pd::size_bytes)
         this->unmap(gpa);
 }
 
 void
-root_ept_intel_x64::unmap_identity_map_4k(
+intel::root_ept::unmap_identity_map_4k(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pt::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pt::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pt::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pt::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pt::size_bytes)
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pt::size_bytes)
         this->unmap(gpa);
 }
 
-ept_entry_intel_x64
-root_ept_intel_x64::gpa_to_epte(integer_pointer gpa) const
+intel::ept_entry
+intel::root_ept::gpa_to_epte(integer_pointer gpa) const
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     return m_ept->gpa_to_epte(gpa);
 }
 
-root_ept_intel_x64::memory_descriptor_list
-root_ept_intel_x64::ept_to_mdl() const
+intel::root_ept::memory_descriptor_list
+intel::root_ept::ept_to_mdl() const
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     return m_ept->ept_to_mdl();
 }
 
-ept_entry_intel_x64
-root_ept_intel_x64::add_page(integer_pointer gpa, size_type size)
+intel::ept_entry
+intel::root_ept::add_page(integer_pointer gpa, size_type size)
 {
     switch (size)
     {
-        case ept::pdpt::size_bytes:
+        case ::intel_x64::ept::pdpt::size_bytes:
             return m_ept->add_page_1g(gpa);
 
-        case ept::pd::size_bytes:
+        case ::intel_x64::ept::pd::size_bytes:
             return m_ept->add_page_2m(gpa);
 
-        case ept::pt::size_bytes:
+        case ::intel_x64::ept::pt::size_bytes:
             return m_ept->add_page_4k(gpa);
 
         default:
@@ -144,7 +144,7 @@ root_ept_intel_x64::add_page(integer_pointer gpa, size_type size)
 }
 
 void
-root_ept_intel_x64::map_page(integer_pointer gpa, integer_pointer phys, attr_type attr, size_type size)
+intel::root_ept::map_page(integer_pointer gpa, integer_pointer phys, attr_type attr, size_type size)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
@@ -155,124 +155,124 @@ root_ept_intel_x64::map_page(integer_pointer gpa, integer_pointer phys, attr_typ
 
     switch (size)
     {
-        case ept::pdpt::size_bytes:
-            entry.set_phys_addr(phys & ~(ept::pdpt::size_bytes - 1));
+        case ::intel_x64::ept::pdpt::size_bytes:
+            entry.set_phys_addr(phys & ~(::intel_x64::ept::pdpt::size_bytes - 1));
             break;
 
-        case ept::pd::size_bytes:
-            entry.set_phys_addr(phys & ~(ept::pd::size_bytes - 1));
+        case ::intel_x64::ept::pd::size_bytes:
+            entry.set_phys_addr(phys & ~(::intel_x64::ept::pd::size_bytes - 1));
             break;
 
-        case ept::pt::size_bytes:
-            entry.set_phys_addr(phys & ~(ept::pt::size_bytes - 1));
-            break;
-    }
-
-    switch (attr)
-    {
-        case ept::memory_attr::rw_uc:
-        case ept::memory_attr::re_uc:
-        case ept::memory_attr::ro_uc:
-        case ept::memory_attr::eo_uc:
-        case ept::memory_attr::pt_uc:
-        case ept::memory_attr::tp_uc:
-            entry.set_memory_type(ept::memory_type::uc);
-            break;
-
-        case ept::memory_attr::rw_wc:
-        case ept::memory_attr::re_wc:
-        case ept::memory_attr::ro_wc:
-        case ept::memory_attr::eo_wc:
-        case ept::memory_attr::pt_wc:
-        case ept::memory_attr::tp_wc:
-            entry.set_memory_type(ept::memory_type::wc);
-            break;
-
-        case ept::memory_attr::rw_wt:
-        case ept::memory_attr::re_wt:
-        case ept::memory_attr::ro_wt:
-        case ept::memory_attr::eo_wt:
-        case ept::memory_attr::pt_wt:
-        case ept::memory_attr::tp_wt:
-            entry.set_memory_type(ept::memory_type::wt);
-            break;
-
-        case ept::memory_attr::rw_wp:
-        case ept::memory_attr::re_wp:
-        case ept::memory_attr::ro_wp:
-        case ept::memory_attr::eo_wp:
-        case ept::memory_attr::pt_wp:
-        case ept::memory_attr::tp_wp:
-            entry.set_memory_type(ept::memory_type::wp);
-            break;
-
-        case ept::memory_attr::rw_wb:
-        case ept::memory_attr::re_wb:
-        case ept::memory_attr::ro_wb:
-        case ept::memory_attr::eo_wb:
-        case ept::memory_attr::pt_wb:
-        case ept::memory_attr::tp_wb:
-            entry.set_memory_type(ept::memory_type::wb);
+        case ::intel_x64::ept::pt::size_bytes:
+            entry.set_phys_addr(phys & ~(::intel_x64::ept::pt::size_bytes - 1));
             break;
     }
 
     switch (attr)
     {
-        case ept::memory_attr::rw_uc:
-        case ept::memory_attr::rw_wc:
-        case ept::memory_attr::rw_wt:
-        case ept::memory_attr::rw_wp:
-        case ept::memory_attr::rw_wb:
+        case ::intel_x64::ept::memory_attr::rw_uc:
+        case ::intel_x64::ept::memory_attr::re_uc:
+        case ::intel_x64::ept::memory_attr::ro_uc:
+        case ::intel_x64::ept::memory_attr::eo_uc:
+        case ::intel_x64::ept::memory_attr::pt_uc:
+        case ::intel_x64::ept::memory_attr::tp_uc:
+            entry.set_memory_type(::intel_x64::ept::memory_type::uc);
+            break;
+
+        case ::intel_x64::ept::memory_attr::rw_wc:
+        case ::intel_x64::ept::memory_attr::re_wc:
+        case ::intel_x64::ept::memory_attr::ro_wc:
+        case ::intel_x64::ept::memory_attr::eo_wc:
+        case ::intel_x64::ept::memory_attr::pt_wc:
+        case ::intel_x64::ept::memory_attr::tp_wc:
+            entry.set_memory_type(::intel_x64::ept::memory_type::wc);
+            break;
+
+        case ::intel_x64::ept::memory_attr::rw_wt:
+        case ::intel_x64::ept::memory_attr::re_wt:
+        case ::intel_x64::ept::memory_attr::ro_wt:
+        case ::intel_x64::ept::memory_attr::eo_wt:
+        case ::intel_x64::ept::memory_attr::pt_wt:
+        case ::intel_x64::ept::memory_attr::tp_wt:
+            entry.set_memory_type(::intel_x64::ept::memory_type::wt);
+            break;
+
+        case ::intel_x64::ept::memory_attr::rw_wp:
+        case ::intel_x64::ept::memory_attr::re_wp:
+        case ::intel_x64::ept::memory_attr::ro_wp:
+        case ::intel_x64::ept::memory_attr::eo_wp:
+        case ::intel_x64::ept::memory_attr::pt_wp:
+        case ::intel_x64::ept::memory_attr::tp_wp:
+            entry.set_memory_type(::intel_x64::ept::memory_type::wp);
+            break;
+
+        case ::intel_x64::ept::memory_attr::rw_wb:
+        case ::intel_x64::ept::memory_attr::re_wb:
+        case ::intel_x64::ept::memory_attr::ro_wb:
+        case ::intel_x64::ept::memory_attr::eo_wb:
+        case ::intel_x64::ept::memory_attr::pt_wb:
+        case ::intel_x64::ept::memory_attr::tp_wb:
+            entry.set_memory_type(::intel_x64::ept::memory_type::wb);
+            break;
+    }
+
+    switch (attr)
+    {
+        case ::intel_x64::ept::memory_attr::rw_uc:
+        case ::intel_x64::ept::memory_attr::rw_wc:
+        case ::intel_x64::ept::memory_attr::rw_wt:
+        case ::intel_x64::ept::memory_attr::rw_wp:
+        case ::intel_x64::ept::memory_attr::rw_wb:
             entry.set_read_access(true);
             entry.set_write_access(true);
             entry.set_execute_access(false);
             break;
 
-        case ept::memory_attr::re_uc:
-        case ept::memory_attr::re_wc:
-        case ept::memory_attr::re_wt:
-        case ept::memory_attr::re_wp:
-        case ept::memory_attr::re_wb:
+        case ::intel_x64::ept::memory_attr::re_uc:
+        case ::intel_x64::ept::memory_attr::re_wc:
+        case ::intel_x64::ept::memory_attr::re_wt:
+        case ::intel_x64::ept::memory_attr::re_wp:
+        case ::intel_x64::ept::memory_attr::re_wb:
             entry.set_read_access(true);
             entry.set_write_access(false);
             entry.set_execute_access(true);
             break;
 
-        case ept::memory_attr::ro_uc:
-        case ept::memory_attr::ro_wc:
-        case ept::memory_attr::ro_wt:
-        case ept::memory_attr::ro_wp:
-        case ept::memory_attr::ro_wb:
+        case ::intel_x64::ept::memory_attr::ro_uc:
+        case ::intel_x64::ept::memory_attr::ro_wc:
+        case ::intel_x64::ept::memory_attr::ro_wt:
+        case ::intel_x64::ept::memory_attr::ro_wp:
+        case ::intel_x64::ept::memory_attr::ro_wb:
             entry.set_read_access(true);
             entry.set_write_access(false);
             entry.set_execute_access(false);
             break;
 
-        case ept::memory_attr::eo_uc:
-        case ept::memory_attr::eo_wc:
-        case ept::memory_attr::eo_wt:
-        case ept::memory_attr::eo_wp:
-        case ept::memory_attr::eo_wb:
+        case ::intel_x64::ept::memory_attr::eo_uc:
+        case ::intel_x64::ept::memory_attr::eo_wc:
+        case ::intel_x64::ept::memory_attr::eo_wt:
+        case ::intel_x64::ept::memory_attr::eo_wp:
+        case ::intel_x64::ept::memory_attr::eo_wb:
             entry.set_read_access(false);
             entry.set_write_access(false);
             entry.set_execute_access(true);
             break;
 
-        case ept::memory_attr::pt_uc:
-        case ept::memory_attr::pt_wc:
-        case ept::memory_attr::pt_wt:
-        case ept::memory_attr::pt_wp:
-        case ept::memory_attr::pt_wb:
+        case ::intel_x64::ept::memory_attr::pt_uc:
+        case ::intel_x64::ept::memory_attr::pt_wc:
+        case ::intel_x64::ept::memory_attr::pt_wt:
+        case ::intel_x64::ept::memory_attr::pt_wp:
+        case ::intel_x64::ept::memory_attr::pt_wb:
             entry.set_read_access(true);
             entry.set_write_access(true);
             entry.set_execute_access(true);
             break;
 
-        case ept::memory_attr::tp_uc:
-        case ept::memory_attr::tp_wc:
-        case ept::memory_attr::tp_wt:
-        case ept::memory_attr::tp_wp:
-        case ept::memory_attr::tp_wb:
+        case ::intel_x64::ept::memory_attr::tp_uc:
+        case ::intel_x64::ept::memory_attr::tp_wc:
+        case ::intel_x64::ept::memory_attr::tp_wt:
+        case ::intel_x64::ept::memory_attr::tp_wp:
+        case ::intel_x64::ept::memory_attr::tp_wb:
             entry.set_read_access(false);
             entry.set_write_access(false);
             entry.set_execute_access(false);
@@ -284,7 +284,7 @@ root_ept_intel_x64::map_page(integer_pointer gpa, integer_pointer phys, attr_typ
 }
 
 void
-root_ept_intel_x64::unmap_page(integer_pointer gpa) noexcept
+intel::root_ept::unmap_page(integer_pointer gpa) noexcept
 {
     guard_exceptions([&]
     { m_ept->remove_page(gpa); });

--- a/src/hve/arch/intel_x64/vmcs/root_ept.cpp
+++ b/src/hve/arch/intel_x64/vmcs/root_ept.cpp
@@ -23,8 +23,8 @@
 #include "../../../../../include/hve/arch/intel_x64/vmcs/root_ept.h"
 #include <bfvmm/memory_manager/memory_manager_x64.h>
 
-namespace ept = ept;
 namespace intel = eapis::hve::intel_x64;
+namespace mem_attr = ::intel_x64::ept::memory_attr;
 
 // -----------------------------------------------------------------------------
 // Implementation
@@ -49,43 +49,43 @@ void
 intel::root_ept::setup_identity_map_1g(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pdpt::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pdpt::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pdpt::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pdpt::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pdpt::size_bytes)
-        this->map_1g(gpa, gpa, ept::memory_attr::pt_wb);
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pdpt::size_bytes)
+        this->map_1g(gpa, gpa, mem_attr::pt_wb);
 }
 
 void
 intel::root_ept::setup_identity_map_2m(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pd::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pd::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pd::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pd::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pd::size_bytes)
-        this->map_2m(gpa, gpa, ept::memory_attr::pt_wb);
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pd::size_bytes)
+        this->map_2m(gpa, gpa, mem_attr::pt_wb);
 }
 
 void
 intel::root_ept::setup_identity_map_4k(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pt::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pt::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pt::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pt::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pt::size_bytes)
-        this->map_4k(gpa, gpa, ept::memory_attr::pt_wb);
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pt::size_bytes)
+        this->map_4k(gpa, gpa, mem_attr::pt_wb);
 }
 
 void
 intel::root_ept::unmap_identity_map_1g(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pdpt::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pdpt::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pdpt::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pdpt::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pdpt::size_bytes)
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pdpt::size_bytes) {
         this->unmap(gpa);
     }
 }
@@ -94,10 +94,10 @@ void
 intel::root_ept::unmap_identity_map_2m(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pd::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pd::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pd::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pd::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pd::size_bytes)
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pd::size_bytes) {
         this->unmap(gpa);
     }
 }
@@ -106,10 +106,10 @@ void
 intel::root_ept::unmap_identity_map_4k(
     integer_pointer saddr, integer_pointer eaddr)
 {
-    expects((saddr & (ept::pt::size_bytes - 1)) == 0);
-    expects((eaddr & (ept::pt::size_bytes - 1)) == 0);
+    expects((saddr & (::intel_x64::ept::pt::size_bytes - 1)) == 0);
+    expects((eaddr & (::intel_x64::ept::pt::size_bytes - 1)) == 0);
 
-    for (auto gpa = saddr; gpa < eaddr; gpa += ept::pt::size_bytes)
+    for (auto gpa = saddr; gpa < eaddr; gpa += ::intel_x64::ept::pt::size_bytes) {
         this->unmap(gpa);
     }
 }
@@ -133,13 +133,13 @@ intel::root_ept::add_page(integer_pointer gpa, size_type size)
 {
     switch (size)
     {
-        case ept::pdpt::size_bytes:
+        case ::intel_x64::ept::pdpt::size_bytes:
             return m_ept->add_page_1g(gpa);
 
-        case ept::pd::size_bytes:
+        case ::intel_x64::ept::pd::size_bytes:
             return m_ept->add_page_2m(gpa);
 
-        case ept::pt::size_bytes:
+        case ::intel_x64::ept::pt::size_bytes:
             return m_ept->add_page_4k(gpa);
 
         default:
@@ -159,124 +159,124 @@ intel::root_ept::map_page(integer_pointer gpa, integer_pointer phys, attr_type a
 
     switch (size)
     {
-        case ept::pdpt::size_bytes:
-            entry.set_phys_addr(phys & ~(ept::pdpt::size_bytes - 1));
+        case ::intel_x64::ept::pdpt::size_bytes:
+            entry.set_phys_addr(phys & ~(::intel_x64::ept::pdpt::size_bytes - 1));
             break;
 
-        case ept::pd::size_bytes:
-            entry.set_phys_addr(phys & ~(ept::pd::size_bytes - 1));
+        case ::intel_x64::ept::pd::size_bytes:
+            entry.set_phys_addr(phys & ~(::intel_x64::ept::pd::size_bytes - 1));
             break;
 
-        case ept::pt::size_bytes:
-            entry.set_phys_addr(phys & ~(ept::pt::size_bytes - 1));
-            break;
-    }
-
-    switch (attr)
-    {
-        case ept::memory_attr::rw_uc:
-        case ept::memory_attr::re_uc:
-        case ept::memory_attr::ro_uc:
-        case ept::memory_attr::eo_uc:
-        case ept::memory_attr::pt_uc:
-        case ept::memory_attr::tp_uc:
-            entry.set_memory_type(ept::memory_type::uc);
-            break;
-
-        case ept::memory_attr::rw_wc:
-        case ept::memory_attr::re_wc:
-        case ept::memory_attr::ro_wc:
-        case ept::memory_attr::eo_wc:
-        case ept::memory_attr::pt_wc:
-        case ept::memory_attr::tp_wc:
-            entry.set_memory_type(ept::memory_type::wc);
-            break;
-
-        case ept::memory_attr::rw_wt:
-        case ept::memory_attr::re_wt:
-        case ept::memory_attr::ro_wt:
-        case ept::memory_attr::eo_wt:
-        case ept::memory_attr::pt_wt:
-        case ept::memory_attr::tp_wt:
-            entry.set_memory_type(ept::memory_type::wt);
-            break;
-
-        case ept::memory_attr::rw_wp:
-        case ept::memory_attr::re_wp:
-        case ept::memory_attr::ro_wp:
-        case ept::memory_attr::eo_wp:
-        case ept::memory_attr::pt_wp:
-        case ept::memory_attr::tp_wp:
-            entry.set_memory_type(ept::memory_type::wp);
-            break;
-
-        case ept::memory_attr::rw_wb:
-        case ept::memory_attr::re_wb:
-        case ept::memory_attr::ro_wb:
-        case ept::memory_attr::eo_wb:
-        case ept::memory_attr::pt_wb:
-        case ept::memory_attr::tp_wb:
-            entry.set_memory_type(ept::memory_type::wb);
+        case ::intel_x64::ept::pt::size_bytes:
+            entry.set_phys_addr(phys & ~(::intel_x64::ept::pt::size_bytes - 1));
             break;
     }
 
     switch (attr)
     {
-        case ept::memory_attr::rw_uc:
-        case ept::memory_attr::rw_wc:
-        case ept::memory_attr::rw_wt:
-        case ept::memory_attr::rw_wp:
-        case ept::memory_attr::rw_wb:
+        case mem_attr::rw_uc:
+        case mem_attr::re_uc:
+        case mem_attr::ro_uc:
+        case mem_attr::eo_uc:
+        case mem_attr::pt_uc:
+        case mem_attr::tp_uc:
+            entry.set_memory_type(::intel_x64::ept::memory_type::uc);
+            break;
+
+        case mem_attr::rw_wc:
+        case mem_attr::re_wc:
+        case mem_attr::ro_wc:
+        case mem_attr::eo_wc:
+        case mem_attr::pt_wc:
+        case mem_attr::tp_wc:
+            entry.set_memory_type(::intel_x64::ept::memory_type::wc);
+            break;
+
+        case mem_attr::rw_wt:
+        case mem_attr::re_wt:
+        case mem_attr::ro_wt:
+        case mem_attr::eo_wt:
+        case mem_attr::pt_wt:
+        case mem_attr::tp_wt:
+            entry.set_memory_type(::intel_x64::ept::memory_type::wt);
+            break;
+
+        case mem_attr::rw_wp:
+        case mem_attr::re_wp:
+        case mem_attr::ro_wp:
+        case mem_attr::eo_wp:
+        case mem_attr::pt_wp:
+        case mem_attr::tp_wp:
+            entry.set_memory_type(::intel_x64::ept::memory_type::wp);
+            break;
+
+        case mem_attr::rw_wb:
+        case mem_attr::re_wb:
+        case mem_attr::ro_wb:
+        case mem_attr::eo_wb:
+        case mem_attr::pt_wb:
+        case mem_attr::tp_wb:
+            entry.set_memory_type(::intel_x64::ept::memory_type::wb);
+            break;
+    }
+
+    switch (attr)
+    {
+        case mem_attr::rw_uc:
+        case mem_attr::rw_wc:
+        case mem_attr::rw_wt:
+        case mem_attr::rw_wp:
+        case mem_attr::rw_wb:
             entry.set_read_access(true);
             entry.set_write_access(true);
             entry.set_execute_access(false);
             break;
 
-        case ept::memory_attr::re_uc:
-        case ept::memory_attr::re_wc:
-        case ept::memory_attr::re_wt:
-        case ept::memory_attr::re_wp:
-        case ept::memory_attr::re_wb:
+        case mem_attr::re_uc:
+        case mem_attr::re_wc:
+        case mem_attr::re_wt:
+        case mem_attr::re_wp:
+        case mem_attr::re_wb:
             entry.set_read_access(true);
             entry.set_write_access(false);
             entry.set_execute_access(true);
             break;
 
-        case ept::memory_attr::ro_uc:
-        case ept::memory_attr::ro_wc:
-        case ept::memory_attr::ro_wt:
-        case ept::memory_attr::ro_wp:
-        case ept::memory_attr::ro_wb:
+        case mem_attr::ro_uc:
+        case mem_attr::ro_wc:
+        case mem_attr::ro_wt:
+        case mem_attr::ro_wp:
+        case mem_attr::ro_wb:
             entry.set_read_access(true);
             entry.set_write_access(false);
             entry.set_execute_access(false);
             break;
 
-        case ept::memory_attr::eo_uc:
-        case ept::memory_attr::eo_wc:
-        case ept::memory_attr::eo_wt:
-        case ept::memory_attr::eo_wp:
-        case ept::memory_attr::eo_wb:
+        case mem_attr::eo_uc:
+        case mem_attr::eo_wc:
+        case mem_attr::eo_wt:
+        case mem_attr::eo_wp:
+        case mem_attr::eo_wb:
             entry.set_read_access(false);
             entry.set_write_access(false);
             entry.set_execute_access(true);
             break;
 
-        case ept::memory_attr::pt_uc:
-        case ept::memory_attr::pt_wc:
-        case ept::memory_attr::pt_wt:
-        case ept::memory_attr::pt_wp:
-        case ept::memory_attr::pt_wb:
+        case mem_attr::pt_uc:
+        case mem_attr::pt_wc:
+        case mem_attr::pt_wt:
+        case mem_attr::pt_wp:
+        case mem_attr::pt_wb:
             entry.set_read_access(true);
             entry.set_write_access(true);
             entry.set_execute_access(true);
             break;
 
-        case ept::memory_attr::tp_uc:
-        case ept::memory_attr::tp_wc:
-        case ept::memory_attr::tp_wt:
-        case ept::memory_attr::tp_wp:
-        case ept::memory_attr::tp_wb:
+        case mem_attr::tp_uc:
+        case mem_attr::tp_wc:
+        case mem_attr::tp_wt:
+        case mem_attr::tp_wp:
+        case mem_attr::tp_wb:
             entry.set_read_access(false);
             entry.set_write_access(false);
             entry.set_execute_access(false);

--- a/src/hve/arch/intel_x64/vmcs/vmcs.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs.cpp
@@ -21,15 +21,17 @@
 
 #include "../../../../../include/hve/arch/intel_x64/vmcs/vmcs.h"
 
-vmcs_intel_x64_eapis::vmcs_intel_x64_eapis()
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
+
+vmcs_eapis::vmcs::vmcs()
 {
-    static intel_x64::vmcs::value_type g_vpid = 1;
+    static ::intel_x64::vmcs::value_type g_vpid = 1;
     m_vpid = g_vpid++;
 }
 
 void
-vmcs_intel_x64_eapis::write_fields(gsl::not_null<vmcs_intel_x64_state *> host_state,
-                                   gsl::not_null<vmcs_intel_x64_state *> guest_state)
+vmcs_eapis::vmcs::write_fields(gsl::not_null<bfvmm::intel_x64::vmcs_state *> host_state,
+                               gsl::not_null<bfvmm::intel_x64::vmcs_state *> guest_state)
 {
     this->disable_ept();
     this->disable_vpid();

--- a/src/hve/arch/intel_x64/vmcs/vmcs_cr.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_cr.cpp
@@ -21,81 +21,80 @@
 
 #include <arch/intel_x64/vmcs.h>
 
-using namespace intel_x64;
-using namespace vmcs;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 void
-vmcs_intel_x64_eapis::enable_cr0_load_hook(mask_type mask, shadow_type shadow)
+vmcs_eapis::vmcs::enable_cr0_load_hook(mask_type mask, shadow_type shadow)
 {
     cr0_guest_host_mask::set(mask);
     cr0_read_shadow::set(shadow);
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr3_load_hook()
+vmcs_eapis::vmcs::enable_cr3_load_hook()
 {
     primary_processor_based_vm_execution_controls::cr3_load_exiting::enable();
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr3_store_hook()
+vmcs_eapis::vmcs::enable_cr3_store_hook()
 {
     primary_processor_based_vm_execution_controls::cr3_store_exiting::enable();
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr4_load_hook(mask_type mask, shadow_type shadow)
+vmcs_eapis::vmcs::enable_cr4_load_hook(mask_type mask, shadow_type shadow)
 {
     cr4_guest_host_mask::set(mask);
     cr4_read_shadow::set(shadow);
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr8_load_hook()
+vmcs_eapis::vmcs::enable_cr8_load_hook()
 {
     primary_processor_based_vm_execution_controls::cr8_load_exiting::enable();
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr8_store_hook()
+vmcs_eapis::vmcs::enable_cr8_store_hook()
 {
     primary_processor_based_vm_execution_controls::cr8_store_exiting::enable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_cr0_load_hook()
+vmcs_eapis::vmcs::disable_cr0_load_hook()
 {
     cr0_guest_host_mask::set(0ULL);
     cr0_read_shadow::set(0ULL);
 }
 
 void
-vmcs_intel_x64_eapis::disable_cr3_load_hook()
+vmcs_eapis::vmcs::disable_cr3_load_hook()
 {
     primary_processor_based_vm_execution_controls::cr3_load_exiting::disable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_cr3_store_hook()
+vmcs_eapis::vmcs::disable_cr3_store_hook()
 {
     primary_processor_based_vm_execution_controls::cr3_store_exiting::disable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_cr4_load_hook()
+vmcs_eapis::vmcs::disable_cr4_load_hook()
 {
     cr4_guest_host_mask::set(0ULL);
     cr4_read_shadow::set(0ULL);
 }
 
 void
-vmcs_intel_x64_eapis::disable_cr8_load_hook()
+vmcs_eapis::vmcs::disable_cr8_load_hook()
 {
     primary_processor_based_vm_execution_controls::cr8_load_exiting::disable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_cr8_store_hook()
+vmcs_eapis::vmcs::disable_cr8_store_hook()
 {
     primary_processor_based_vm_execution_controls::cr8_store_exiting::disable();
 }

--- a/src/hve/arch/intel_x64/vmcs/vmcs_cr_access_hooks.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_cr_access_hooks.cpp
@@ -22,75 +22,74 @@
 #include "../../../../../include/hve/arch/intel_x64/vmcs/vmcs.h"
 #include <intrinsics.h>
 
-using namespace intel_x64;
-using namespace vmcs;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 void
-vmcs_intel_x64_eapis::enable_cr0_load_hook(mask_type mask, shadow_type shadow)
+vmcs_eapis::vmcs::enable_cr0_load_hook(mask_type mask, shadow_type shadow)
 {
-    cr0_guest_host_mask::set(mask);
-    cr0_read_shadow::set(shadow);
-}
-
-void
-vmcs_intel_x64_eapis::enable_cr3_load_hook()
-{
-    primary_processor_based_vm_execution_controls::cr3_load_exiting::enable();
+    ::intel_x64::vmcs::cr0_guest_host_mask::set(mask);
+    ::intel_x64::vmcs::cr0_read_shadow::set(shadow);
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr3_store_hook()
+vmcs_eapis::vmcs::enable_cr3_load_hook()
 {
-    primary_processor_based_vm_execution_controls::cr3_store_exiting::enable();
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::cr3_load_exiting::enable();
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr4_load_hook(mask_type mask, shadow_type shadow)
+vmcs_eapis::vmcs::enable_cr3_store_hook()
 {
-    cr4_guest_host_mask::set(mask);
-    cr4_read_shadow::set(shadow);
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::cr3_store_exiting::enable();
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr8_load_hook()
+vmcs_eapis::vmcs::enable_cr4_load_hook(mask_type mask, shadow_type shadow)
 {
-    primary_processor_based_vm_execution_controls::cr8_load_exiting::enable();
+    ::intel_x64::vmcs::cr4_guest_host_mask::set(mask);
+    ::intel_x64::vmcs::cr4_read_shadow::set(shadow);
 }
 
 void
-vmcs_intel_x64_eapis::enable_cr8_store_hook()
+vmcs_eapis::vmcs::enable_cr8_load_hook()
 {
-    primary_processor_based_vm_execution_controls::cr8_store_exiting::enable();
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::cr8_load_exiting::enable();
 }
 
-void vmcs_intel_x64_eapis::disable_cr0_load_hook()
+void
+vmcs_eapis::vmcs::enable_cr8_store_hook()
 {
-    cr0_guest_host_mask::set(0ULL);
-    cr0_read_shadow::set(0ULL);
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::cr8_store_exiting::enable();
 }
 
-void vmcs_intel_x64_eapis::disable_cr3_load_hook()
+void vmcs_eapis::vmcs::disable_cr0_load_hook()
 {
-    primary_processor_based_vm_execution_controls::cr3_load_exiting::disable();
+    ::intel_x64::vmcs::cr0_guest_host_mask::set(0ULL);
+    ::intel_x64::vmcs::cr0_read_shadow::set(0ULL);
 }
 
-void vmcs_intel_x64_eapis::disable_cr3_store_hook()
+void vmcs_eapis::vmcs::disable_cr3_load_hook()
 {
-    primary_processor_based_vm_execution_controls::cr3_store_exiting::disable();
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::cr3_load_exiting::disable();
 }
 
-void vmcs_intel_x64_eapis::disable_cr4_load_hook()
+void vmcs_eapis::vmcs::disable_cr3_store_hook()
 {
-    cr4_guest_host_mask::set(0ULL);
-    cr4_read_shadow::set(0ULL);
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::cr3_store_exiting::disable();
 }
 
-void vmcs_intel_x64_eapis::disable_cr8_load_hook()
+void vmcs_eapis::vmcs::disable_cr4_load_hook()
 {
-    primary_processor_based_vm_execution_controls::cr8_load_exiting::disable();
+    ::intel_x64::vmcs::cr4_guest_host_mask::set(0ULL);
+    ::intel_x64::vmcs::cr4_read_shadow::set(0ULL);
 }
 
-void vmcs_intel_x64_eapis::disable_cr8_store_hook()
+void vmcs_eapis::vmcs::disable_cr8_load_hook()
 {
-    primary_processor_based_vm_execution_controls::cr8_store_exiting::disable();
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::cr8_load_exiting::disable();
+}
+
+void vmcs_eapis::vmcs::disable_cr8_store_hook()
+{
+    ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::cr8_store_exiting::disable();
 }

--- a/src/hve/arch/intel_x64/vmcs/vmcs_cr_access_hooks.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_cr_access_hooks.cpp
@@ -22,15 +22,14 @@
 #include "../../../../../include/hve/arch/intel_x64/vmcs/vmcs.h"
 #include <intrinsics.h>
 
-namespace vmcs = ::intel_x64::vmcs;
-namespace proc_ctls = vmcs::primary_processor_based_vm_execution_controls;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
 namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 void
 vmcs_eapis::vmcs::enable_cr0_load_hook(mask_type mask, shadow_type shadow)
 {
-    vmcs::cr0_guest_host_mask::set(mask);
-    vmcs::cr0_read_shadow::set(shadow);
+    ::intel_x64::vmcs::cr0_guest_host_mask::set(mask);
+    ::intel_x64::vmcs::cr0_read_shadow::set(shadow);
 }
 
 void
@@ -48,8 +47,8 @@ vmcs_eapis::vmcs::enable_cr3_store_hook()
 void
 vmcs_eapis::vmcs::enable_cr4_load_hook(mask_type mask, shadow_type shadow)
 {
-    vmcs::cr4_guest_host_mask::set(mask);
-    vmcs::cr4_read_shadow::set(shadow);
+    ::intel_x64::vmcs::cr4_guest_host_mask::set(mask);
+    ::intel_x64::vmcs::cr4_read_shadow::set(shadow);
 }
 
 void
@@ -66,8 +65,8 @@ vmcs_eapis::vmcs::enable_cr8_store_hook()
 
 void vmcs_eapis::vmcs::disable_cr0_load_hook()
 {
-    vmcs::cr0_guest_host_mask::set(0ULL);
-    vmcs::cr0_read_shadow::set(0ULL);
+    ::intel_x64::vmcs::cr0_guest_host_mask::set(0ULL);
+    ::intel_x64::vmcs::cr0_read_shadow::set(0ULL);
 }
 
 void vmcs_eapis::vmcs::disable_cr3_load_hook()
@@ -82,8 +81,8 @@ void vmcs_eapis::vmcs::disable_cr3_store_hook()
 
 void vmcs_eapis::vmcs::disable_cr4_load_hook()
 {
-    vmcs::cr4_guest_host_mask::set(0ULL);
-    vmcs::cr4_read_shadow::set(0ULL);
+    ::intel_x64::vmcs::cr4_guest_host_mask::set(0ULL);
+    ::intel_x64::vmcs::cr4_read_shadow::set(0ULL);
 }
 
 void vmcs_eapis::vmcs::disable_cr8_load_hook()

--- a/src/hve/arch/intel_x64/vmcs/vmcs_ept.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_ept.cpp
@@ -24,36 +24,37 @@
 
 #include <intrinsics.h>
 
-using namespace intel_x64;
-using namespace vmcs;
+namespace ept_p = ::intel_x64::vmcs::ept_pointer;
+namespace proc_ctls2 = ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 void
-vmcs_intel_x64_eapis::enable_ept(eptp_type eptp)
+vmcs_eapis::vmcs::enable_ept(eptp_type eptp)
 {
-    ept_entry_intel_x64 entry{&eptp};
+    ept_entry entry{&eptp};
 
-    ept_pointer::phys_addr::set(entry.phys_addr());
-    ept_pointer::memory_type::set(ept_pointer::memory_type::write_back);
-    ept_pointer::page_walk_length_minus_one::set(3ULL);
+    ept_p::phys_addr::set(entry.phys_addr());
+    ept_p::memory_type::set(ept_p::memory_type::write_back);
+    ept_p::page_walk_length_minus_one::set(3ULL);
 
-    secondary_processor_based_vm_execution_controls::enable_ept::enable();
+    proc_ctls2::enable_ept::enable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_ept()
+vmcs_eapis::vmcs::disable_ept()
 {
-    intel_x64::vmx::invept_global();
-    secondary_processor_based_vm_execution_controls::enable_ept::disable();
+    ::intel_x64::vmx::invept_global();
+    proc_ctls2::enable_ept::disable();
 
-    ept_pointer::set(0UL);
+    ept_p::set(0UL);
 }
 
 void
-vmcs_intel_x64_eapis::set_eptp(integer_pointer eptp)
+vmcs_eapis::vmcs::set_eptp(integer_pointer eptp)
 {
-    auto &&entry = ept_entry_intel_x64{&eptp};
+    auto &&entry = ept_entry{&eptp};
 
-    ept_pointer::memory_type::set(ept_pointer::memory_type::write_back);
-    ept_pointer::page_walk_length_minus_one::set(3UL);
-    ept_pointer::phys_addr::set(entry.phys_addr());
+    ept_p::memory_type::set(ept_p::memory_type::write_back);
+    ept_p::page_walk_length_minus_one::set(3UL);
+    ept_p::phys_addr::set(entry.phys_addr());
 }

--- a/src/hve/arch/intel_x64/vmcs/vmcs_event.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_event.cpp
@@ -21,12 +21,12 @@
 
 #include "../../../../../include/hve/arch/intel_x64/vmcs/vmcs.h"
 
-using namespace x64;
-using namespace intel_x64;
-using namespace vmcs;
+namespace pin_ctls = ::intel_x64::vmcs::pin_based_vm_execution_controls;
+namespace exit_ctls = ::intel_x64::vmcs::vm_exit_controls;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 void
-vmcs_intel_x64_eapis::enable_event_management()
+vmcs_eapis::vmcs::enable_event_management()
 {
     // if (intel_x64::cpuid::feature_information::ecx::x2apic::is_disabled()) {
     //     throw std::runtime_error("x2apic not supported: failed to enable event management");
@@ -67,12 +67,12 @@ vmcs_intel_x64_eapis::enable_event_management()
     // bfdebug_nhex(0, "838", x64::msrs::get(0x838U));
     // bfdebug_nhex(0, "839", x64::msrs::get(0x839U));
 
-    pin_based_vm_execution_controls::external_interrupt_exiting::enable();
-    vm_exit_controls::acknowledge_interrupt_on_exit::enable();
+    pin_ctls::external_interrupt_exiting::enable();
+    exit_ctls::acknowledge_interrupt_on_exit::enable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_event_management()
+vmcs_eapis::vmcs::disable_event_management()
 {
     // if (primary_processor_based_vm_execution_controls::use_msr_bitmap::is_disabled()) {
     //     throw std::runtime_error("msr bitmaps not enabled: failed to disable event management");
@@ -85,6 +85,6 @@ vmcs_intel_x64_eapis::disable_event_management()
     // this->disable_cr8_load_hook();
     // this->disable_cr8_store_hook();
 
-    vm_exit_controls::acknowledge_interrupt_on_exit::enable();
-    pin_based_vm_execution_controls::external_interrupt_exiting::disable();
+    exit_ctls::acknowledge_interrupt_on_exit::enable();
+    pin_ctls::external_interrupt_exiting::disable();
 }

--- a/src/hve/arch/intel_x64/vmcs/vmcs_io.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_io.cpp
@@ -28,7 +28,6 @@
 #include <intrinsics.h>
 #include <intrinsics.h>
 
-namespace vmcs = ::intel_x64::vmcs;
 namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
 namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
@@ -40,8 +39,8 @@ vmcs_eapis::vmcs::enable_io_bitmaps()
     m_io_bitmapa_view = gsl::make_span(m_io_bitmapa, x64::page_size);
     m_io_bitmapb_view = gsl::make_span(m_io_bitmapb, x64::page_size);
 
-    vmcs::address_of_io_bitmap_a::set(g_mm->virtptr_to_physint(m_io_bitmapa.get()));
-    vmcs::address_of_io_bitmap_b::set(g_mm->virtptr_to_physint(m_io_bitmapb.get()));
+    ::intel_x64::vmcs::address_of_io_bitmap_a::set(g_mm->virtptr_to_physint(m_io_bitmapa.get()));
+    ::intel_x64::vmcs::address_of_io_bitmap_b::set(g_mm->virtptr_to_physint(m_io_bitmapb.get()));
 
     proc_ctls::use_io_bitmaps::enable();
 }
@@ -51,8 +50,8 @@ vmcs_eapis::vmcs::disable_io_bitmaps()
 {
     proc_ctls::use_io_bitmaps::disable();
 
-    vmcs::address_of_io_bitmap_a::set(0UL);
-    vmcs::address_of_io_bitmap_b::set(0UL);
+    ::intel_x64::vmcs::address_of_io_bitmap_a::set(0UL);
+    ::intel_x64::vmcs::address_of_io_bitmap_b::set(0UL);
 
     m_io_bitmapa_view = gsl::span<uint8_t>(nullptr);
     m_io_bitmapb_view = gsl::span<uint8_t>(nullptr);

--- a/src/hve/arch/intel_x64/vmcs/vmcs_io.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_io.cpp
@@ -28,30 +28,30 @@
 #include <intrinsics.h>
 #include <intrinsics.h>
 
-using namespace intel_x64;
-using namespace vmcs;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 void
-vmcs_intel_x64_eapis::enable_io_bitmaps()
+vmcs_eapis::vmcs::enable_io_bitmaps()
 {
     m_io_bitmapa = std::make_unique<uint8_t[]>(x64::page_size);
     m_io_bitmapb = std::make_unique<uint8_t[]>(x64::page_size);
     m_io_bitmapa_view = gsl::make_span(m_io_bitmapa, x64::page_size);
     m_io_bitmapb_view = gsl::make_span(m_io_bitmapb, x64::page_size);
 
-    address_of_io_bitmap_a::set(g_mm->virtptr_to_physint(m_io_bitmapa.get()));
-    address_of_io_bitmap_b::set(g_mm->virtptr_to_physint(m_io_bitmapb.get()));
+    ::intel_x64::vmcs::address_of_io_bitmap_a::set(g_mm->virtptr_to_physint(m_io_bitmapa.get()));
+    ::intel_x64::vmcs::address_of_io_bitmap_b::set(g_mm->virtptr_to_physint(m_io_bitmapb.get()));
 
-    primary_processor_based_vm_execution_controls::use_io_bitmaps::enable();
+    proc_ctls::use_io_bitmaps::enable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_io_bitmaps()
+vmcs_eapis::vmcs::disable_io_bitmaps()
 {
-    primary_processor_based_vm_execution_controls::use_io_bitmaps::disable();
+    proc_ctls::use_io_bitmaps::disable();
 
-    address_of_io_bitmap_a::set(0UL);
-    address_of_io_bitmap_b::set(0UL);
+    ::intel_x64::vmcs::address_of_io_bitmap_a::set(0UL);
+    ::intel_x64::vmcs::address_of_io_bitmap_b::set(0UL);
 
     m_io_bitmapa_view = gsl::span<uint8_t>(nullptr);
     m_io_bitmapb_view = gsl::span<uint8_t>(nullptr);
@@ -60,7 +60,7 @@ vmcs_intel_x64_eapis::disable_io_bitmaps()
 }
 
 void
-vmcs_intel_x64_eapis::trap_on_io_access(port_type port)
+vmcs_eapis::vmcs::trap_on_io_access(port_type port)
 {
     if (!m_io_bitmapa || !m_io_bitmapb)
         throw std::runtime_error("io bitmaps not enabled");
@@ -78,7 +78,7 @@ vmcs_intel_x64_eapis::trap_on_io_access(port_type port)
 }
 
 void
-vmcs_intel_x64_eapis::trap_on_all_io_accesses()
+vmcs_eapis::vmcs::trap_on_all_io_accesses()
 {
     if (!m_io_bitmapa || !m_io_bitmapb)
         throw std::runtime_error("io bitmaps not enabled");
@@ -88,7 +88,7 @@ vmcs_intel_x64_eapis::trap_on_all_io_accesses()
 }
 
 void
-vmcs_intel_x64_eapis::pass_through_io_access(port_type port)
+vmcs_eapis::vmcs::pass_through_io_access(port_type port)
 {
     if (!m_io_bitmapa || !m_io_bitmapb)
         throw std::runtime_error("io bitmaps not enabled");
@@ -106,7 +106,7 @@ vmcs_intel_x64_eapis::pass_through_io_access(port_type port)
 }
 
 void
-vmcs_intel_x64_eapis::pass_through_all_io_accesses()
+vmcs_eapis::vmcs::pass_through_all_io_accesses()
 {
     if (!m_io_bitmapa || !m_io_bitmapb)
         throw std::runtime_error("io bitmaps not enabled");
@@ -116,7 +116,7 @@ vmcs_intel_x64_eapis::pass_through_all_io_accesses()
 }
 
 void
-vmcs_intel_x64_eapis::whitelist_io_access(const port_list_type &ports)
+vmcs_eapis::vmcs::whitelist_io_access(const port_list_type &ports)
 {
     trap_on_all_io_accesses();
     for (auto port : ports)
@@ -124,7 +124,7 @@ vmcs_intel_x64_eapis::whitelist_io_access(const port_list_type &ports)
 }
 
 void
-vmcs_intel_x64_eapis::blacklist_io_access(const port_list_type &ports)
+vmcs_eapis::vmcs::blacklist_io_access(const port_list_type &ports)
 {
     pass_through_all_io_accesses();
     for (auto port : ports)

--- a/src/hve/arch/intel_x64/vmcs/vmcs_isr.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_isr.cpp
@@ -28,9 +28,6 @@
 #include <intrinsics.h>
 #include <intrinsics.h>
 
-using namespace x64;
-using namespace intel_x64;
-
 extern "C" void unlock_write(void);
 
 static auto
@@ -82,7 +79,7 @@ isr_handler(
         bferror_info(0, "VMM Panic!!!", msg);
         bferror_brk1(0, msg);
 
-        if (vector == 0x0E && cr2::get() == 0) {
+        if (vector == 0x0E && ::intel_x64::cr2::get() == 0) {
             bferror_info(0, "fault: null dereference", msg);
         }
         else {
@@ -118,11 +115,11 @@ isr_handler(
         bferror_subnhex(0, "r14   ", view[1], msg);
         bferror_subnhex(0, "r15   ", view[0], msg);
 
-        bferror_subnhex(0, "cr0   ", cr0::get(), msg);
-        bferror_subnhex(0, "cr2   ", cr2::get(), msg);
-        bferror_subnhex(0, "cr3   ", cr3::get(), msg);
-        bferror_subnhex(0, "cr4   ", cr4::get(), msg);
+        bferror_subnhex(0, "cr0   ", ::intel_x64::cr0::get(), msg);
+        bferror_subnhex(0, "cr2   ", ::intel_x64::cr2::get(), msg);
+        bferror_subnhex(0, "cr3   ", ::intel_x64::cr3::get(), msg);
+        bferror_subnhex(0, "cr4   ", ::intel_x64::cr4::get(), msg);
     });
 
-    pm::halt();
+    ::x64::pm::halt();
 }

--- a/src/hve/arch/intel_x64/vmcs/vmcs_msr.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_msr.cpp
@@ -28,8 +28,9 @@
 #include <intrinsics.h>
 #include <intrinsics.h>
 
-using namespace intel_x64;
-using namespace vmcs;
+namespace msr_bitmap_address = ::intel_x64::vmcs::address_of_msr_bitmap;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 /// Note:
 ///
@@ -57,27 +58,27 @@ using namespace vmcs;
 ///
 
 void
-vmcs_intel_x64_eapis::enable_msr_bitmap()
+vmcs_eapis::vmcs::enable_msr_bitmap()
 {
     m_msr_bitmap = std::make_unique<uint8_t[]>(x64::page_size);
     m_msr_bitmap_view = gsl::make_span(m_msr_bitmap, x64::page_size);
 
-    address_of_msr_bitmap::set(g_mm->virtptr_to_physint(m_msr_bitmap.get()));
-    primary_processor_based_vm_execution_controls::use_msr_bitmap::enable();
+    msr_bitmap_address::set(g_mm->virtptr_to_physint(m_msr_bitmap.get()));
+    proc_ctls::use_msr_bitmap::enable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_msr_bitmap()
+vmcs_eapis::vmcs::disable_msr_bitmap()
 {
-    primary_processor_based_vm_execution_controls::use_msr_bitmap::disable();
-    address_of_msr_bitmap::set(0UL);
+    proc_ctls::use_msr_bitmap::disable();
+    msr_bitmap_address::set(0UL);
 
     m_msr_bitmap_view = gsl::span<uint8_t>(nullptr);
     m_msr_bitmap.reset();
 }
 
 void
-vmcs_intel_x64_eapis::trap_on_rdmsr_access(msr_type msr)
+vmcs_eapis::vmcs::trap_on_rdmsr_access(msr_type msr)
 {
     if (!m_msr_bitmap)
         throw std::runtime_error("msr bitmap not enabled");
@@ -98,7 +99,7 @@ vmcs_intel_x64_eapis::trap_on_rdmsr_access(msr_type msr)
 }
 
 void
-vmcs_intel_x64_eapis::trap_on_wrmsr_access(msr_type msr)
+vmcs_eapis::vmcs::trap_on_wrmsr_access(msr_type msr)
 {
     if (!m_msr_bitmap)
         throw std::runtime_error("msr bitmap not enabled");
@@ -119,7 +120,7 @@ vmcs_intel_x64_eapis::trap_on_wrmsr_access(msr_type msr)
 }
 
 void
-vmcs_intel_x64_eapis::trap_on_all_rdmsr_accesses()
+vmcs_eapis::vmcs::trap_on_all_rdmsr_accesses()
 {
     if (!m_msr_bitmap)
         throw std::runtime_error("msr bitmap not enabled");
@@ -128,7 +129,7 @@ vmcs_intel_x64_eapis::trap_on_all_rdmsr_accesses()
 }
 
 void
-vmcs_intel_x64_eapis::trap_on_all_wrmsr_accesses()
+vmcs_eapis::vmcs::trap_on_all_wrmsr_accesses()
 {
     if (!m_msr_bitmap)
         throw std::runtime_error("msr bitmap not enabled");
@@ -137,7 +138,7 @@ vmcs_intel_x64_eapis::trap_on_all_wrmsr_accesses()
 }
 
 void
-vmcs_intel_x64_eapis::pass_through_rdmsr_access(msr_type msr)
+vmcs_eapis::vmcs::pass_through_rdmsr_access(msr_type msr)
 {
     if (!m_msr_bitmap)
         throw std::runtime_error("msr bitmap not enabled");
@@ -158,7 +159,7 @@ vmcs_intel_x64_eapis::pass_through_rdmsr_access(msr_type msr)
 }
 
 void
-vmcs_intel_x64_eapis::pass_through_wrmsr_access(msr_type msr)
+vmcs_eapis::vmcs::pass_through_wrmsr_access(msr_type msr)
 {
     if (!m_msr_bitmap)
         throw std::runtime_error("msr bitmap not enabled");
@@ -179,7 +180,7 @@ vmcs_intel_x64_eapis::pass_through_wrmsr_access(msr_type msr)
 }
 
 void
-vmcs_intel_x64_eapis::pass_through_all_rdmsr_accesses()
+vmcs_eapis::vmcs::pass_through_all_rdmsr_accesses()
 {
     if (!m_msr_bitmap)
         throw std::runtime_error("msr bitmap not enabled");
@@ -188,7 +189,7 @@ vmcs_intel_x64_eapis::pass_through_all_rdmsr_accesses()
 }
 
 void
-vmcs_intel_x64_eapis::pass_through_all_wrmsr_accesses()
+vmcs_eapis::vmcs::pass_through_all_wrmsr_accesses()
 {
     if (!m_msr_bitmap)
         throw std::runtime_error("msr bitmap not enabled");
@@ -197,7 +198,7 @@ vmcs_intel_x64_eapis::pass_through_all_wrmsr_accesses()
 }
 
 void
-vmcs_intel_x64_eapis::whitelist_rdmsr_access(msr_list_type msrs)
+vmcs_eapis::vmcs::whitelist_rdmsr_access(msr_list_type msrs)
 {
     trap_on_all_rdmsr_accesses();
     for (auto msr : msrs)
@@ -205,7 +206,7 @@ vmcs_intel_x64_eapis::whitelist_rdmsr_access(msr_list_type msrs)
 }
 
 void
-vmcs_intel_x64_eapis::whitelist_wrmsr_access(msr_list_type msrs)
+vmcs_eapis::vmcs::whitelist_wrmsr_access(msr_list_type msrs)
 {
     trap_on_all_wrmsr_accesses();
     for (auto msr : msrs)
@@ -213,7 +214,7 @@ vmcs_intel_x64_eapis::whitelist_wrmsr_access(msr_list_type msrs)
 }
 
 void
-vmcs_intel_x64_eapis::blacklist_rdmsr_access(msr_list_type msrs)
+vmcs_eapis::vmcs::blacklist_rdmsr_access(msr_list_type msrs)
 {
     pass_through_all_rdmsr_accesses();
     for (auto msr : msrs)
@@ -221,7 +222,7 @@ vmcs_intel_x64_eapis::blacklist_rdmsr_access(msr_list_type msrs)
 }
 
 void
-vmcs_intel_x64_eapis::blacklist_wrmsr_access(msr_list_type msrs)
+vmcs_eapis::vmcs::blacklist_wrmsr_access(msr_list_type msrs)
 {
     pass_through_all_wrmsr_accesses();
     for (auto msr : msrs)

--- a/src/hve/arch/intel_x64/vmcs/vmcs_vmm_state.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_vmm_state.cpp
@@ -23,8 +23,7 @@
 #include <bfvmm/hve/arch/x64/idt.h>
 #include "../../../../../include/hve/arch/intel_x64/vmcs/vmcs_vmm_state.h"
 
-using namespace x64;
-using namespace intel_x64;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 // -----------------------------------------------------------------------------
 // Interrupt Service Routines
@@ -298,7 +297,7 @@ extern "C" void _isr255(void) noexcept;
 // VMM State Implementation
 // -----------------------------------------------------------------------------
 
-vmcs_intel_x64_vmm_state_eapis::vmcs_intel_x64_vmm_state_eapis()
+vmcs_eapis::vmcs_state_vmm::vmcs_state_vmm()
 {
     m_idt.set(0, _isr0, 0x8);
     m_idt.set(1, _isr1, 0x8);

--- a/src/hve/arch/intel_x64/vmcs/vmcs_vpid.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_vpid.cpp
@@ -22,20 +22,19 @@
 #include "../../../../../include/hve/arch/intel_x64/vmcs/vmcs.h"
 #include <intrinsics.h>
 
-namespace vmcs = ::intel_x64::vmcs;
 namespace proc_ctls2 = ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 void
 vmcs_eapis::vmcs::enable_vpid()
 {
-    vmcs::virtual_processor_identifier::set(m_vpid);
+    ::intel_x64::vmcs::virtual_processor_identifier::set(m_vpid);
     proc_ctls2::enable_vpid::enable();
 }
 
 void
 vmcs_eapis::vmcs::disable_vpid()
 {
-    vmcs::virtual_processor_identifier::set(0UL);
+    ::intel_x64::vmcs::virtual_processor_identifier::set(0UL);
     proc_ctls2::enable_vpid::disable();
 }

--- a/src/hve/arch/intel_x64/vmcs/vmcs_vpid.cpp
+++ b/src/hve/arch/intel_x64/vmcs/vmcs_vpid.cpp
@@ -23,19 +23,19 @@
 #include <intrinsics.h>
 #include <intrinsics.h>
 
-using namespace intel_x64;
-using namespace vmcs;
+namespace proc_ctls2 = ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 void
-vmcs_intel_x64_eapis::enable_vpid()
+vmcs_eapis::vmcs::enable_vpid()
 {
-    vmcs::virtual_processor_identifier::set(m_vpid);
-    secondary_processor_based_vm_execution_controls::enable_vpid::enable();
+    ::intel_x64::vmcs::virtual_processor_identifier::set(m_vpid);
+    proc_ctls2::enable_vpid::enable();
 }
 
 void
-vmcs_intel_x64_eapis::disable_vpid()
+vmcs_eapis::vmcs::disable_vpid()
 {
-    vmcs::virtual_processor_identifier::set(0UL);
-    secondary_processor_based_vm_execution_controls::enable_vpid::disable();
+    ::intel_x64::vmcs::virtual_processor_identifier::set(0UL);
+    proc_ctls2::enable_vpid::disable();
 }

--- a/src/policy/arch/intel_x64/vmcall_policy.cpp
+++ b/src/policy/arch/intel_x64/vmcall_policy.cpp
@@ -27,8 +27,10 @@
 #include <hve/arch/intel_x64/exit_handler/rdmsr_verifiers.h>
 #include <hve/arch/intel_x64/exit_handler/wrmsr_verifiers.h>
 
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
+
 void
-exit_handler_intel_x64_eapis::init_policy()
+exit_handler_eapis::exit_handler::init_policy()
 {
     m_verifiers[vp::index_clear_denials] = std::make_unique<default_verifier__clear_denials>();
     m_verifiers[vp::index_dump_policy] = std::make_unique<default_verifier__dump_policy>();

--- a/src/vcpu/arch/intel_x64/vcpu_factory.cpp
+++ b/src/vcpu/arch/intel_x64/vcpu_factory.cpp
@@ -29,20 +29,20 @@
 #include "../../../../include/hve/arch/intel_x64/vmcs/vmcs_vmm_state.h"
 #include "../../../../include/hve/arch/intel_x64/exit_handler/exit_handler.h"
 
-using vmcs_eapis = vmcs_intel_x64_eapis;
-using vmm_state_eapis = vmcs_intel_x64_vmm_state_eapis;
-using exit_handler_eapis = exit_handler_intel_x64_eapis;
+using eapis_vmcs = eapis::hve::intel_x64::vmcs::vmcs;
+using eapis_vmm_state = eapis::hve::intel_x64::vmcs::vmcs_state_vmm;
+using eapis_exit_handler = eapis::hve::intel_x64::exit_handler::exit_handler;
 
-std::unique_ptr<vcpu>
-vcpu_factory::make_vcpu(vcpuid::type vcpuid, user_data *data)
+std::unique_ptr<bfvmm::vcpu>
+bfvmm::vcpu_factory::make_vcpu(vcpuid::type vcpuid, user_data *data)
 {
     bfignored(data);
 
-    auto vmcs = std::make_unique<vmcs_eapis>();
-    auto vmm_state = std::make_unique<vmm_state_eapis>();
-    auto exit_handler = std::make_unique<exit_handler_eapis>();
+    auto vmcs = std::make_unique<eapis_vmcs>();
+    auto vmm_state = std::make_unique<eapis_vmm_state>();
+    auto exit_handler = std::make_unique<eapis_exit_handler>();
 
-    return std::make_unique<vcpu_intel_x64>(
+    return std::make_unique<bfvmm::intel_x64::vcpu>(
                vcpuid,
                nullptr,                         // default vmxon
                std::move(vmcs),

--- a/tests/hve/arch/intel_x64/exit_handler/test_cpuid_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_cpuid_emulation.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 namespace reason = vmcs::exit_reason::basic_exit_reason;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: passthrough not logged")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_cpuid_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_cpuid_emulation.cpp
@@ -21,21 +21,20 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-namespace reason = vmcs::exit_reason::basic_exit_reason;
+namespace reason = ::intel_x64::vmcs::exit_reason::basic_exit_reason;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: passthrough not logged")
+TEST_CASE("eapis_exit_handler_cpuid_emulation: passthrough not logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::cpuid);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_regs_type m_regs = x64::cpuid::get(leaf, 0, subleaf, 0);
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_regs_type m_regs = x64::cpuid::get(leaf, 0, subleaf, 0);
 
     CHECK_NOTHROW(ehlr->log_cpuid_access(false));
     CHECK_NOTHROW(ehlr->clear_cpuid_access_log());
@@ -52,15 +51,15 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: passthrough not logged"
     CHECK(ehlr->m_state_save->rdx == m_regs.rdx);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: passthrough logged")
+TEST_CASE("eapis_exit_handler_cpuid_emulation: passthrough logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::cpuid);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_regs_type m_regs = x64::cpuid::get(leaf, 0, subleaf, 0);
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_regs_type m_regs = x64::cpuid::get(leaf, 0, subleaf, 0);
 
     CHECK_NOTHROW(ehlr->log_cpuid_access(true));
     CHECK_NOTHROW(ehlr->clear_cpuid_access_log());
@@ -69,7 +68,6 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: passthrough logged")
 
     bfdebug_nhex(0, "log size:",  ehlr->m_cpuid_access_log.size());
     CHECK_NOTHROW(ehlr->dispatch());
-    ehlr->m_cpuid_access_log[0] = 1;
     CHECK(ehlr->m_cpuid_access_log[0] == 1);
     CHECK(ehlr->m_cpuid_emu_map.empty());
 
@@ -79,15 +77,15 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: passthrough logged")
     CHECK(ehlr->m_state_save->rdx == m_regs.rdx);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: emulation not logged")
+TEST_CASE("eapis_exit_handler_cpuid_emulation: emulation not logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::cpuid);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_regs_type regs = { 1, 7, 3, 8 };
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_regs_type regs = { 1, 7, 3, 8 };
     ehlr->m_cpuid_emu_map[0] = regs;
 
     CHECK_NOTHROW(ehlr->log_cpuid_access(false));
@@ -105,15 +103,15 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: emulation not logged")
     CHECK(ehlr->m_state_save->rdx == 8);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_emulation: emulation logged")
+TEST_CASE("eapis_exit_handler_cpuid_emulation: emulation logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::cpuid);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_regs_type regs = { 1, 7, 3, 8 };
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_regs_type regs = { 1, 7, 3, 8 };
     ehlr->m_cpuid_emu_map[0] = regs;
 
     CHECK_NOTHROW(ehlr->log_cpuid_access(true));

--- a/tests/hve/arch/intel_x64/exit_handler/test_cpuid_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_cpuid_vmcall.cpp
@@ -21,20 +21,18 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
+namespace exit_handler_eapis = eapis::hve::intel_x64::exit_handler;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid missing args")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json emulate cpuid missing args")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
     std::string valid = "00000000000000000000000000001000";
 
     json ijson1 = {{"command", "emulate_cpuid"}};
@@ -47,14 +45,14 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid missing
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid invalid args")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json emulate cpuid invalid args")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
     std::string valid = "00000000000000000000000000001000";
 
     json ijson1 = {{"command", "emulate_cpuid"}, {"leaf", "bad leaf"}, {"subleaf", "bad subleaf"},
@@ -73,14 +71,14 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid invalid
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson3, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid invalid string")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json emulate cpuid invalid string")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
     std::string long_string = "0000000000000000000000000000001000";
     std::string short_string =                        "0000001000";
     std::string unknown_chars = "00000000000000000000000000001jwz";
@@ -130,14 +128,14 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid invalid
     CHECK(ehlr->m_cpuid_emu_map[0].rdx == 8);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid allowed")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json emulate cpuid allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
     std::string valid =   "00000000000000000000000000001000";
 
     json ijson = {{"command", "emulate_cpuid"}, {"leaf", leaf}, {"subleaf", subleaf},
@@ -160,14 +158,14 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid allowed
     CHECK(ehlr->m_cpuid_emu_map[0].rdx == 8);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid logged")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json emulate cpuid logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
     std::string valid =   "00000000000000000000000000001000";
 
     json ijson = {{"command", "emulate_cpuid"}, {"leaf", leaf}, {"subleaf", subleaf},
@@ -191,14 +189,14 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid logged"
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid denied")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json emulate cpuid denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
     auto ehlr = setup_ehlr(vmcs);
 
-    exit_handler_intel_x64_eapis::cpuid_type leaf = 0;
-    exit_handler_intel_x64_eapis::cpuid_type subleaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type leaf = 0;
+    exit_handler_eapis::exit_handler::cpuid_type subleaf = 0;
     std::string valid =   "00000000000000000000000000001000";
 
     json ijson = {{"command", "emulate_cpuid"}, {"leaf", leaf}, {"subleaf", subleaf},
@@ -221,7 +219,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid denied"
     CHECK(ehlr->m_cpuid_emu_map[0].rdx != 8);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf missing args")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json reset cpuid leaf missing args")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -233,7 +231,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf miss
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf invalid args")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json reset cpuid leaf invalid args")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -245,7 +243,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf inva
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf allowed")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json reset cpuid leaf allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -265,7 +263,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf allo
     CHECK(ehlr->m_cpuid_emu_map.find(0) == ehlr->m_cpuid_emu_map.end());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf logged")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json reset cpuid leaf logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -286,7 +284,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf logg
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf denied")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json reset cpuid leaf denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -306,7 +304,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid leaf deni
     CHECK(ehlr->m_cpuid_emu_map.find(0) != ehlr->m_cpuid_emu_map.end());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid all allowed")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json reset cpuid all allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -326,7 +324,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid all allow
     CHECK(ehlr->m_cpuid_emu_map.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid all logged")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json reset cpuid all logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -347,7 +345,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid all logge
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid all denied")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json reset cpuid all denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -367,7 +365,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json reset cpuid all denie
     CHECK_FALSE(ehlr->m_cpuid_emu_map.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access missing enabled")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json log cpuid access missing enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -379,7 +377,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access miss
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access invalid enabled")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json log cpuid access invalid enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -391,7 +389,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access inva
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access allowed")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json log cpuid access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -409,7 +407,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access allo
     CHECK(ojson.dump() == "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access logged")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json log cpuid access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -428,7 +426,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access logg
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access denied")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json log cpuid access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -446,7 +444,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json log cpuid access deni
     CHECK(ojson.dump() != "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json clear cpuid access log allowed")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json clear cpuid access log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -464,7 +462,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json clear cpuid access lo
     CHECK(ojson.dump() == "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json clear cpuid access log logged")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json clear cpuid access log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -483,7 +481,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json clear cpuid access lo
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json clear cpuid access log denied")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json clear cpuid access log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -501,7 +499,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json clear cpuid access lo
     CHECK(ojson.dump() != "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json cpuid access log allowed")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json cpuid access log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -520,7 +518,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json cpuid access log allo
     CHECK(ojson.dump() == "{\"0x0000000000000000\":8}");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json cpuid access log logged")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json cpuid access log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -540,7 +538,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json cpuid access log logg
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json cpuid access log denied")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json cpuid access log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -559,7 +557,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json cpuid access log deni
     CHECK(ojson.dump() != "{\"0x0000000000000000\":8}");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json dump cpuid emulations log allowed")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json dump cpuid emulations log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -578,7 +576,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json dump cpuid emulations
     CHECK(ojson.dump() == "{\"0x0000000000000000\":[8,8,8,8]}");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json dump cpuid emulations log logged")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json dump cpuid emulations log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -598,7 +596,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json dump cpuid emulations
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json dump cpuid emulations log denied")
+TEST_CASE("eapis_exit_handler_cpuid_vmcall: json dump cpuid emulations log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/exit_handler/test_cpuid_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_cpuid_vmcall.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_cpuid_vmcall: json emulate cpuid missing args")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_cr_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_cr_emulation.cpp
@@ -21,16 +21,14 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-namespace reason = vmcs::exit_reason::basic_exit_reason;
-namespace exit_qual = vmcs::exit_qualification;
+namespace reason = ::intel_x64::vmcs::exit_reason::basic_exit_reason;
+namespace exit_qual = ::intel_x64::vmcs::exit_qualification;
 namespace ctlreg_access = exit_qual::control_register_access;
 namespace gpr = ctlreg_access::general_purpose_register;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: invalid cr")
+TEST_CASE("eapis_exit_handler_cr_emulation: invalid cr")
 {
     MockRepository mocks;
 
@@ -40,7 +38,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: invalid cr")
     CHECK_NOTHROW(ehlr->dispatch());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov to cr0")
+TEST_CASE("eapis_exit_handler_cr_emulation: mov to cr0")
 {
     MockRepository mocks;
 
@@ -50,10 +48,10 @@ TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov to cr0")
     g_state_save.rax = 42ULL;
 
     CHECK_NOTHROW(ehlr->dispatch());
-    CHECK(vmcs::guest_cr0::get() == 42ULL);
+    CHECK(::intel_x64::vmcs::guest_cr0::get() == 42ULL);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov to cr3")
+TEST_CASE("eapis_exit_handler_cr_emulation: mov to cr3")
 {
     MockRepository mocks;
 
@@ -63,23 +61,23 @@ TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov to cr3")
     g_state_save.rax = 42ULL;
 
     CHECK_NOTHROW(ehlr->dispatch());
-    CHECK(vmcs::guest_cr3::get() == 42ULL);
+    CHECK(::intel_x64::vmcs::guest_cr3::get() == 42ULL);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov from cr3")
+TEST_CASE("eapis_exit_handler_cr_emulation: mov from cr3")
 {
     MockRepository mocks;
 
     auto vmcs = setup_vmcs(mocks, reason::control_register_accesses, 19);
     auto ehlr = setup_ehlr(vmcs);
 
-    vmcs::guest_cr3::set(42ULL);
+    ::intel_x64::vmcs::guest_cr3::set(42ULL);
 
     CHECK_NOTHROW(ehlr->dispatch());
     CHECK(g_state_save.rax == 42ULL);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov to cr4")
+TEST_CASE("eapis_exit_handler_cr_emulation: mov to cr4")
 {
     MockRepository mocks;
 
@@ -89,10 +87,10 @@ TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov to cr4")
     g_state_save.rax = 42ULL;
 
     CHECK_NOTHROW(ehlr->dispatch());
-    CHECK(vmcs::guest_cr4::get() == 42ULL);
+    CHECK(::intel_x64::vmcs::guest_cr4::get() == 42ULL);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov to cr8")
+TEST_CASE("eapis_exit_handler_cr_emulation: mov to cr8")
 {
     MockRepository mocks;
 
@@ -102,23 +100,23 @@ TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov to cr8")
     g_state_save.rax = 42ULL;
 
     CHECK_NOTHROW(ehlr->dispatch());
-    CHECK(intel::cr8::get() == 42ULL);
+    CHECK(::intel_x64::cr8::get() == 42ULL);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: mov from cr8")
+TEST_CASE("eapis_exit_handler_cr_emulation: mov from cr8")
 {
     MockRepository mocks;
 
     auto vmcs = setup_vmcs(mocks, reason::control_register_accesses, 24);
     auto ehlr = setup_ehlr(vmcs);
 
-    intel::cr8::set(42ULL);
+    ::intel_x64::cr8::set(42ULL);
 
     CHECK_NOTHROW(ehlr->dispatch());
     CHECK(g_state_save.rax == 42ULL);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: get_gpr")
+TEST_CASE("eapis_exit_handler_cr_emulation: get_gpr")
 {
     MockRepository mocks;
 
@@ -145,7 +143,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: get_gpr")
     CHECK_THROWS(ehlr->get_gpr(0x1000));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: set_gpr")
+TEST_CASE("eapis_exit_handler_cr_emulation: set_gpr")
 {
     MockRepository mocks;
 

--- a/tests/hve/arch/intel_x64/exit_handler/test_cr_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_cr_emulation.cpp
@@ -19,6 +19,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
@@ -28,7 +30,6 @@ namespace exit_qual = vmcs::exit_qualification;
 namespace ctlreg_access = exit_qual::control_register_access;
 namespace gpr = ctlreg_access::general_purpose_register;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_cr_emulation: invalid cr")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_exit_handler.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_exit_handler.cpp
@@ -21,13 +21,9 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis: resume")
+TEST_CASE("eapis_exit_handler: resume")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -36,7 +32,7 @@ TEST_CASE("exit_handler_intel_x64_eapis: resume")
     CHECK_NOTHROW(ehlr->resume());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis: resume_and_advance")
+TEST_CASE("eapis_exit_handler: resume_and_advance")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -46,7 +42,7 @@ TEST_CASE("exit_handler_intel_x64_eapis: resume_and_advance")
     CHECK(ehlr->m_state_save->rip == g_rip);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis: exit invalid")
+TEST_CASE("eapis_exit_handler: exit invalid")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -55,7 +51,7 @@ TEST_CASE("exit_handler_intel_x64_eapis: exit invalid")
     CHECK_NOTHROW(ehlr->dispatch());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis: vmcall registers unknown")
+TEST_CASE("eapis_exit_handler: vmcall registers unknown")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -67,7 +63,7 @@ TEST_CASE("exit_handler_intel_x64_eapis: vmcall registers unknown")
     CHECK_THROWS(ehlr->handle_vmcall_registers(regs));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis: vmcall json unknown")
+TEST_CASE("eapis_exit_handler: vmcall json unknown")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/exit_handler/test_exit_handler.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_exit_handler.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis: resume")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_io_instruction_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_io_instruction_emulation.cpp
@@ -19,6 +19,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
@@ -27,7 +29,6 @@ namespace io_qual = vmcs::exit_qualification::io_instruction;
 namespace reason = vmcs::exit_reason::basic_exit_reason;
 namespace proc_ctls = vmcs::primary_processor_based_vm_execution_controls;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_emulation: exit")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_io_instruction_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_io_instruction_emulation.cpp
@@ -21,35 +21,33 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-namespace io_qual = vmcs::exit_qualification::io_instruction;
-namespace reason = vmcs::exit_reason::basic_exit_reason;
-namespace proc_ctls = vmcs::primary_processor_based_vm_execution_controls;
+namespace io_qual = ::intel_x64::vmcs::exit_qualification::io_instruction;
+namespace reason = ::intel_x64::vmcs::exit_reason::basic_exit_reason;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_emulation: exit")
+TEST_CASE("eapis_exit_handler_io_instruction_emulation: exit")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::io_instruction);
     auto ehlr = setup_ehlr(vmcs);
 
     ehlr->log_io_access(true);
-    g_vmcs[vmcs::exit_qualification::addr] = 42 << io_qual::port_number::from;
+    g_vmcs[::intel_x64::vmcs::exit_qualification::addr] = 42 << io_qual::port_number::from;
 
     CHECK_NOTHROW(ehlr->dispatch());
     CHECK(ehlr->m_io_access_log[42] == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_emulation: log io access enabled")
+TEST_CASE("eapis_exit_handler_io_instruction_emulation: log io access enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::io_instruction);
     auto ehlr = setup_ehlr(vmcs);
 
     ehlr->log_io_access(true);
-    g_vmcs[vmcs::exit_qualification::addr] = 42 << io_qual::port_number::from;
+    g_vmcs[::intel_x64::vmcs::exit_qualification::addr] = 42 << io_qual::port_number::from;
 
     g_vmcs[proc_ctls::addr] = 0xFFFFFFFFFFFFFFFF;
 
@@ -57,19 +55,19 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_emulation: log io access 
     CHECK(ehlr->m_io_access_log[42] == 1);
     CHECK(proc_ctls::use_io_bitmaps::is_disabled());
 
-    g_vmcs[vmcs::exit_reason::addr] = reason::monitor_trap_flag;
+    g_vmcs[::intel_x64::vmcs::exit_reason::addr] = reason::monitor_trap_flag;
     ehlr->dispatch();
     CHECK(proc_ctls::use_io_bitmaps::is_enabled());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_emulation: log io access disabled")
+TEST_CASE("eapis_exit_handler_io_instruction_emulation: log io access disabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::io_instruction);
     auto ehlr = setup_ehlr(vmcs);
 
     ehlr->log_io_access(false);
-    g_vmcs[vmcs::exit_qualification::addr] = 42 << io_qual::port_number::from;
+    g_vmcs[::intel_x64::vmcs::exit_qualification::addr] = 42 << io_qual::port_number::from;
 
     g_vmcs[proc_ctls::addr] = 0xFFFFFFFFFFFFFFFF;
 
@@ -77,19 +75,19 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_emulation: log io access 
     CHECK(ehlr->m_io_access_log[42] == 0);
     CHECK(proc_ctls::use_io_bitmaps::is_disabled());
 
-    g_vmcs[vmcs::exit_reason::addr] = reason::monitor_trap_flag;
+    g_vmcs[::intel_x64::vmcs::exit_reason::addr] = reason::monitor_trap_flag;
     ehlr->dispatch();
     CHECK(proc_ctls::use_io_bitmaps::is_enabled());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_emulation: clear io access log")
+TEST_CASE("eapis_exit_handler_io_instruction_emulation: clear io access log")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::io_instruction);
     auto ehlr = setup_ehlr(vmcs);
 
     ehlr->log_io_access(true);
-    g_vmcs[vmcs::exit_qualification::addr] = 42 << io_qual::port_number::from;
+    g_vmcs[::intel_x64::vmcs::exit_qualification::addr] = 42 << io_qual::port_number::from;
 
     ehlr->dispatch();
     CHECK(ehlr->m_io_access_log[42] == 1);

--- a/tests/hve/arch/intel_x64/exit_handler/test_io_instruction_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_io_instruction_vmcall.cpp
@@ -21,13 +21,9 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register unknown")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register unknown")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -40,7 +36,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register unknown"
     CHECK_THROWS(ehlr->handle_vmcall_registers(regs));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register enable io bitmaps allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register enable io bitmaps allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -61,7 +57,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register enable i
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register enable io bitmaps logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register enable io bitmaps logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -82,7 +78,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register enable i
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register enable io bitmaps denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register enable io bitmaps denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -103,7 +99,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register enable i
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register disable io bitmaps allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register disable io bitmaps allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -124,7 +120,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register disable 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register disable io bitmaps logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register disable io bitmaps logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -145,7 +141,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register disable 
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register disable io bitmaps denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register disable io bitmaps denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -166,7 +162,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register disable 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on io access allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register trap on io access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -188,7 +184,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on io access logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register trap on io access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -210,7 +206,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on 
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on io access denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register trap on io access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -232,7 +228,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on all io accesses allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register trap on all io accesses allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -253,7 +249,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on all io accesses logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register trap on all io accesses logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -274,7 +270,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on 
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on all io accesses denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register trap on all io accesses denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -295,7 +291,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register trap on 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass through io access allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register pass through io access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -317,7 +313,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass thr
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass through io access logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register pass through io access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -339,7 +335,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass thr
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass through io access denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register pass through io access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -361,7 +357,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass thr
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass through all io accesses allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register pass through all io accesses allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -382,7 +378,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass thr
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass through all io accesses logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register pass through all io accesses logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -403,7 +399,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass thr
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass through all io accesses denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: register pass through all io accesses denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -424,7 +420,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register pass thr
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bitmaps missing enabled")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json enable io bitmaps missing enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -436,7 +432,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bi
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bitmaps invalid enabled")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json enable io bitmaps invalid enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -448,7 +444,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bi
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bitmaps allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json enable io bitmaps allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -474,7 +470,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bi
     CHECK(!g_enable_io_bitmaps);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bitmaps logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json enable io bitmaps logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -502,7 +498,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bi
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bitmaps denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json enable io bitmaps denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -528,7 +524,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json enable io bi
     CHECK(g_enable_io_bitmaps);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io access missing port")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json trap on io access missing port")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -540,7 +536,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io a
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io access invalid port")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json trap on io access invalid port")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -554,7 +550,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io a
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io access allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json trap on io access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -580,7 +576,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io a
     CHECK(g_port == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io access logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json trap on io access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -608,7 +604,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io a
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io access denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json trap on io access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -634,7 +630,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json trap on io a
     CHECK(g_port == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through io access missing port")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json pass through io access missing port")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -646,7 +642,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through io access invalid port")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json pass through io access invalid port")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -660,7 +656,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through io access allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json pass through io access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -686,7 +682,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through
     CHECK(g_port == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through io access logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json pass through io access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -714,7 +710,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through io access denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json pass through io access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -740,7 +736,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json pass through
     CHECK(g_port == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io access missing ports")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json whitelist io access missing ports")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -752,7 +748,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io access invalid ports")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json whitelist io access invalid ports")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -766,7 +762,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io access allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json whitelist io access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -792,7 +788,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io
     CHECK(g_port == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io access logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json whitelist io access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -820,7 +816,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io access denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json whitelist io access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -846,7 +842,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json whitelist io
     CHECK(g_port == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io access missing ports")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json blacklist io access missing ports")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -858,7 +854,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io access invalid ports")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json blacklist io access invalid ports")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -872,7 +868,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io access allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json blacklist io access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -898,7 +894,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io
     CHECK(g_port == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io access logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json blacklist io access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -926,7 +922,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io access denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json blacklist io access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -952,7 +948,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json blacklist io
     CHECK(g_port == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io access missing enabled")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json log io access missing enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -964,7 +960,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io access invalid enabled")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json log io access invalid enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -976,7 +972,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io access allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json log io access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -994,7 +990,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io acces
     CHECK(ojson.dump() == "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io access logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json log io access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -1013,7 +1009,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io acces
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io access denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json log io access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -1031,7 +1027,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json log io acces
     CHECK(ojson.dump() != "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json clear io access log allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json clear io access log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -1049,7 +1045,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json clear io acc
     CHECK(ojson.dump() == "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json clear io access log logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json clear io access log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -1068,7 +1064,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json clear io acc
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json clear io access log denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json clear io access log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -1086,7 +1082,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json clear io acc
     CHECK(ojson.dump() != "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json io access log allowed")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json io access log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -1105,7 +1101,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json io access lo
     CHECK(ojson.dump() == "{\"0x000000000000002A\":42}");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json io access log logged")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json io access log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -1125,7 +1121,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json io access lo
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: json io access log denied")
+TEST_CASE("eapis_exit_handler_io_instruction_vmcall: json io access log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/exit_handler/test_io_instruction_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_io_instruction_vmcall.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_io_instruction_vmcall: register unknown")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_monitor_trap_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_monitor_trap_emulation.cpp
@@ -19,6 +19,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
@@ -26,7 +28,6 @@ namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 namespace reason = vmcs::exit_reason::basic_exit_reason;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_monitor_trap_emulation: exit")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_monitor_trap_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_monitor_trap_emulation.cpp
@@ -21,14 +21,11 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-namespace reason = vmcs::exit_reason::basic_exit_reason;
+namespace reason = ::intel_x64::vmcs::exit_reason::basic_exit_reason;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_monitor_trap_emulation: exit")
+TEST_CASE("eapis_exit_handler_monitor_trap_emulation: exit")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::monitor_trap_flag);
@@ -38,7 +35,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_monitor_trap_emulation: exit")
     CHECK_NOTHROW(ehlr->dispatch());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_monitor_trap_emulation: register trap")
+TEST_CASE("eapis_exit_handler_monitor_trap_emulation: register trap")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::monitor_trap_flag);
@@ -52,7 +49,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_monitor_trap_emulation: register trap")
     CHECK_THROWS(ehlr->dispatch());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_monitor_trap_emulation: clear trap")
+TEST_CASE("eapis_exit_handler_monitor_trap_emulation: clear trap")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, reason::monitor_trap_flag);

--- a/tests/hve/arch/intel_x64/exit_handler/test_msr_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_msr_vmcall.cpp
@@ -21,13 +21,9 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register unknown")
+TEST_CASE("eapis_exit_handler_msr_vmcall: register unknown")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -40,7 +36,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register unknown")
     CHECK_THROWS(ehlr->handle_vmcall_registers(regs));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register enable msr bitmap allowed")
+TEST_CASE("eapis_exit_handler_msr_vmcall: register enable msr bitmap allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -61,7 +57,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register enable msr bitmap a
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register enable msr bitmap logged")
+TEST_CASE("eapis_exit_handler_msr_vmcall: register enable msr bitmap logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -82,7 +78,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register enable msr bitmap l
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register enable msr bitmap denied")
+TEST_CASE("eapis_exit_handler_msr_vmcall: register enable msr bitmap denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -103,7 +99,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register enable msr bitmap d
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register disable msr bitmap allowed")
+TEST_CASE("eapis_exit_handler_msr_vmcall: register disable msr bitmap allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -124,7 +120,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register disable msr bitmap 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register disable msr bitmap logged")
+TEST_CASE("eapis_exit_handler_msr_vmcall: register disable msr bitmap logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -145,7 +141,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register disable msr bitmap 
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register disable msr bitmap denied")
+TEST_CASE("eapis_exit_handler_msr_vmcall: register disable msr bitmap denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -166,7 +162,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register disable msr bitmap 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap missing enabled")
+TEST_CASE("eapis_exit_handler_msr_vmcall: json enable msr bitmap missing enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -178,7 +174,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap missi
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap invalid enabled")
+TEST_CASE("eapis_exit_handler_msr_vmcall: json enable msr bitmap invalid enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -190,7 +186,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap inval
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap allowed")
+TEST_CASE("eapis_exit_handler_msr_vmcall: json enable msr bitmap allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -210,7 +206,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap allow
     CHECK(!g_enable_msr_bitmap);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap logged")
+TEST_CASE("eapis_exit_handler_msr_vmcall: json enable msr bitmap logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -231,7 +227,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap logge
     CHECK(!g_enable_msr_bitmap);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: json enable msr bitmap denied")
+TEST_CASE("eapis_exit_handler_msr_vmcall: json enable msr bitmap denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/exit_handler/test_msr_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_msr_vmcall.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_msr_vmcall: register unknown")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_policy.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_policy.cpp
@@ -19,4 +19,6 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
+#endif

--- a/tests/hve/arch/intel_x64/exit_handler/test_rdmsr_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_rdmsr_emulation.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_emulation: exit")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_rdmsr_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_rdmsr_emulation.cpp
@@ -21,16 +21,14 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
+namespace reason = ::intel_x64::vmcs::exit_reason::basic_exit_reason;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_emulation: exit")
+TEST_CASE("eapis_exit_handler_rdmsr_emulation: exit")
 {
     MockRepository mocks;
-    auto vmcs = setup_vmcs(mocks, vmcs::exit_reason::basic_exit_reason::rdmsr);
+    auto vmcs = setup_vmcs(mocks, reason::rdmsr);
     auto ehlr = setup_ehlr(vmcs);
 
     ehlr->log_rdmsr_access(true);

--- a/tests/hve/arch/intel_x64/exit_handler/test_rdmsr_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_rdmsr_vmcall.cpp
@@ -21,13 +21,9 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register unknown")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register unknown")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -40,7 +36,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register unknown")
     CHECK_THROWS(ehlr->handle_vmcall_registers(regs));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on rdmsr access allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register trap on rdmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -62,7 +58,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on rdmsr acc
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on rdmsr access logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register trap on rdmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -84,7 +80,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on rdmsr acc
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on rdmsr access denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register trap on rdmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -106,7 +102,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on rdmsr acc
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on all rdmsr accesses allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register trap on all rdmsr accesses allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -127,7 +123,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on all rdmsr
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on all rdmsr accesses logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register trap on all rdmsr accesses logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -148,7 +144,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on all rdmsr
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on all rdmsr accesses denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register trap on all rdmsr accesses denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -169,7 +165,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register trap on all rdmsr
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through rdmsr access allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register pass through rdmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -191,7 +187,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through rdms
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through rdmsr access logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register pass through rdmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -213,7 +209,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through rdms
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through rdmsr access denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register pass through rdmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -235,7 +231,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through rdms
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through all rdmsr accesses allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register pass through all rdmsr accesses allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -256,7 +252,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through all 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through all rdmsr accesses logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register pass through all rdmsr accesses logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -277,7 +273,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through all 
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through all rdmsr accesses denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: register pass through all rdmsr accesses denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -298,7 +294,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register pass through all 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access missing msr")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json trap on rdmsr access missing msr")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -310,7 +306,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access 
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access invalid msr")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json trap on rdmsr access invalid msr")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -324,7 +320,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access 
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json trap on rdmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -350,7 +346,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access 
     CHECK(g_rdmsr == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json trap on rdmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -378,7 +374,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access 
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json trap on rdmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -404,7 +400,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json trap on rdmsr access 
     CHECK(g_rdmsr == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr access missing rdmsr")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json pass through rdmsr access missing rdmsr")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -416,7 +412,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr ac
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr access invalid msr")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json pass through rdmsr access invalid msr")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -430,7 +426,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr ac
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr access allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json pass through rdmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -456,7 +452,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr ac
     CHECK(g_rdmsr == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr access logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json pass through rdmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -484,7 +480,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr ac
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr access denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json pass through rdmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -510,7 +506,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json pass through rdmsr ac
     CHECK(g_rdmsr == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr access missing rdmsrs")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json whitelist rdmsr access missing rdmsrs")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -522,7 +518,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr access invalid msrs")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json whitelist rdmsr access invalid msrs")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -536,7 +532,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr access allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json whitelist rdmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -562,7 +558,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr acces
     CHECK(g_rdmsr == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr access logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json whitelist rdmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -590,7 +586,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr acces
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr access denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json whitelist rdmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -616,7 +612,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json whitelist rdmsr acces
     CHECK(g_rdmsr == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr access missing rdmsrs")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json blacklist rdmsr access missing rdmsrs")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -628,7 +624,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr access invalid msrs")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json blacklist rdmsr access invalid msrs")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -642,7 +638,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr access allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json blacklist rdmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -668,7 +664,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr acces
     CHECK(g_rdmsr == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr access logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json blacklist rdmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -696,7 +692,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr acces
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr access denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json blacklist rdmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -722,7 +718,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json blacklist rdmsr acces
     CHECK(g_rdmsr == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access missing enabled")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json log rdmsr access missing enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -734,7 +730,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access miss
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access invalid enabled")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json log rdmsr access invalid enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -746,7 +742,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access inva
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json log rdmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -764,7 +760,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access allo
     CHECK(ojson.dump() == "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json log rdmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -783,7 +779,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access logg
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json log rdmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -801,7 +797,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json log rdmsr access deni
     CHECK(ojson.dump() != "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json clear rdmsr access log allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json clear rdmsr access log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -819,7 +815,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json clear rdmsr access lo
     CHECK(ojson.dump() == "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json clear rdmsr access log logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json clear rdmsr access log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -838,7 +834,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json clear rdmsr access lo
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json clear rdmsr access log denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json clear rdmsr access log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -856,7 +852,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json clear rdmsr access lo
     CHECK(ojson.dump() != "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json rdmsr access log allowed")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json rdmsr access log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -875,7 +871,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json rdmsr access log allo
     CHECK(ojson.dump() == "{\"0x000000000000002A\":42}");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json rdmsr access log logged")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json rdmsr access log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -895,7 +891,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json rdmsr access log logg
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: json rdmsr access log denied")
+TEST_CASE("eapis_exit_handler_rdmsr_vmcall: json rdmsr access log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/exit_handler/test_rdmsr_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_rdmsr_vmcall.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_rdmsr_vmcall: register unknown")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_verifiers.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_verifiers.cpp
@@ -21,13 +21,9 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: overrun denials buffer")
+TEST_CASE("eapis_exit_handler_verifiers: overrun denials buffer")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/exit_handler/test_verifiers.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_verifiers.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_verifiers: overrun denials buffer")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_verifiers_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_verifiers_vmcall.cpp
@@ -21,13 +21,9 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json clear denials allowed")
+TEST_CASE("eapis_exit_handler_verifiers: json clear denials allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -45,7 +41,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json clear denials allowed")
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json clear denials logged")
+TEST_CASE("eapis_exit_handler_verifiers: json clear denials logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -63,7 +59,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json clear denials logged")
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json clear denials denied")
+TEST_CASE("eapis_exit_handler_verifiers: json clear denials denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -81,7 +77,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json clear denials denied")
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump policy allowed")
+TEST_CASE("eapis_exit_handler_verifiers: json dump policy allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -96,7 +92,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump policy allowed")
     CHECK_NOTHROW(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump policy logged")
+TEST_CASE("eapis_exit_handler_verifiers: json dump policy logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -111,7 +107,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump policy logged")
     CHECK_NOTHROW(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump policy denied")
+TEST_CASE("eapis_exit_handler_verifiers: json dump policy denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -126,7 +122,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump policy denied")
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump denials allowed")
+TEST_CASE("eapis_exit_handler_verifiers: json dump denials allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -144,7 +140,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump denials allowed")
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump denials logged")
+TEST_CASE("eapis_exit_handler_verifiers: json dump denials logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -161,7 +157,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump denials logged")
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json dump denials denied")
+TEST_CASE("eapis_exit_handler_verifiers: json dump denials denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/exit_handler/test_verifiers_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_verifiers_vmcall.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_verifiers: json clear denials allowed")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_vpid_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_vpid_vmcall.cpp
@@ -21,13 +21,9 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register unknown")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: register unknown")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -40,7 +36,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register unknown")
     CHECK_THROWS(ehlr->handle_vmcall_registers(regs));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register enable vpid allowed")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: register enable vpid allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -61,7 +57,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register enable vpid allowe
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register enable vpid logged")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: register enable vpid logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -82,7 +78,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register enable vpid logged
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register enable vpid denied")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: register enable vpid denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -103,7 +99,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register enable vpid denied
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register disable vpid allowed")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: register disable vpid allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -124,7 +120,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register disable vpid allow
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register disable vpid logged")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: register disable vpid logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -145,7 +141,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register disable vpid logge
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register disable vpid denied")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: register disable vpid denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -166,7 +162,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register disable vpid denie
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid missing enabled")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: json vpid enable vpid missing enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -178,7 +174,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid missi
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid invalid enabled")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: json vpid enable vpid invalid enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -190,7 +186,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid inval
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid allowed")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: json vpid enable vpid allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -210,7 +206,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid allow
     CHECK(!g_enable_vpid);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid logged")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: json vpid enable vpid logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -231,7 +227,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid logge
     CHECK(!g_enable_vpid);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: json vpid enable vpid denied")
+TEST_CASE("eapis_exit_handler_vpid_vmcall: json vpid enable vpid denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/exit_handler/test_vpid_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_vpid_vmcall.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_vpid_vmcall: register unknown")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_wrmsr_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_wrmsr_emulation.cpp
@@ -19,12 +19,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_emulation: exit")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_wrmsr_emulation.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_wrmsr_emulation.cpp
@@ -21,15 +21,14 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
+namespace reason = ::intel_x64::vmcs::exit_reason::basic_exit_reason;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_emulation: exit")
+TEST_CASE("eapis_exit_handler_wrmsr_emulation: exit")
 {
     MockRepository mocks;
-    auto vmcs = setup_vmcs(mocks, vmcs::exit_reason::basic_exit_reason::wrmsr);
+    auto vmcs = setup_vmcs(mocks, reason::wrmsr);
     auto ehlr = setup_ehlr(vmcs);
 
     ehlr->log_wrmsr_access(true);

--- a/tests/hve/arch/intel_x64/exit_handler/test_wrmsr_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_wrmsr_vmcall.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 using namespace x64;
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register unknown")
 {

--- a/tests/hve/arch/intel_x64/exit_handler/test_wrmsr_vmcall.cpp
+++ b/tests/hve/arch/intel_x64/exit_handler/test_wrmsr_vmcall.cpp
@@ -21,13 +21,9 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-using namespace x64;
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register unknown")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register unknown")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -40,7 +36,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register unknown")
     CHECK_THROWS(ehlr->handle_vmcall_registers(regs));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on wrmsr access allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register trap on wrmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -62,7 +58,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on wrmsr acc
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on wrmsr access logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register trap on wrmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -84,7 +80,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on wrmsr acc
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on wrmsr access denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register trap on wrmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -106,7 +102,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on wrmsr acc
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on all wrmsr accesses allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register trap on all wrmsr accesses allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -127,7 +123,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on all wrmsr
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on all wrmsr accesses logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register trap on all wrmsr accesses logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -148,7 +144,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on all wrmsr
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on all wrmsr accesses denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register trap on all wrmsr accesses denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -169,7 +165,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register trap on all wrmsr
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through wrmsr access allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register pass through wrmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -191,7 +187,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through wrms
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through wrmsr access logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register pass through wrmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -213,7 +209,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through wrms
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through wrmsr access denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register pass through wrmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -235,7 +231,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through wrms
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through all wrmsr accesses allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register pass through all wrmsr accesses allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -256,7 +252,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through all 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through all wrmsr accesses logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register pass through all wrmsr accesses logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -277,7 +273,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through all 
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through all wrmsr accesses denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: register pass through all wrmsr accesses denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -298,7 +294,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: register pass through all 
     CHECK(ehlr->m_denials.empty());
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access missing msr")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json trap on wrmsr access missing msr")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -310,7 +306,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access 
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access invalid msr")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json trap on wrmsr access invalid msr")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -324,7 +320,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access 
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json trap on wrmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -350,7 +346,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access 
     CHECK(g_wrmsr == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json trap on wrmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -378,7 +374,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access 
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json trap on wrmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -404,7 +400,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json trap on wrmsr access 
     CHECK(g_wrmsr == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr access missing wrmsr")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json pass through wrmsr access missing wrmsr")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -416,7 +412,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr ac
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr access invalid msr")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json pass through wrmsr access invalid msr")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -430,7 +426,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr ac
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr access allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json pass through wrmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -456,7 +452,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr ac
     CHECK(g_wrmsr == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr access logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json pass through wrmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -484,7 +480,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr ac
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr access denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json pass through wrmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -510,7 +506,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json pass through wrmsr ac
     CHECK(g_wrmsr == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr access missing wrmsrs")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json whitelist wrmsr access missing wrmsrs")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -522,7 +518,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr access invalid msrs")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json whitelist wrmsr access invalid msrs")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -536,7 +532,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr access allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json whitelist wrmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -562,7 +558,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr acces
     CHECK(g_wrmsr == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr access logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json whitelist wrmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -590,7 +586,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr acces
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr access denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json whitelist wrmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -616,7 +612,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json whitelist wrmsr acces
     CHECK(g_wrmsr == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr access missing wrmsrs")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json blacklist wrmsr access missing wrmsrs")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -628,7 +624,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr access invalid msrs")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json blacklist wrmsr access invalid msrs")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -642,7 +638,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr acces
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson2, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr access allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json blacklist wrmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -668,7 +664,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr acces
     CHECK(g_wrmsr == 42);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr access logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json blacklist wrmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -696,7 +692,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr acces
     CHECK(ehlr->m_denials.size() == 2);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr access denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json blacklist wrmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -722,7 +718,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json blacklist wrmsr acces
     CHECK(g_wrmsr == 0);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access missing enabled")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json log wrmsr access missing enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -734,7 +730,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access miss
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access invalid enabled")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json log wrmsr access invalid enabled")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -746,7 +742,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access inva
     CHECK_THROWS(ehlr->handle_vmcall_data_string_json(ijson, ojson));
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json log wrmsr access allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -764,7 +760,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access allo
     CHECK(ojson.dump() == "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json log wrmsr access logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -783,7 +779,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access logg
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json log wrmsr access denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -801,7 +797,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json log wrmsr access deni
     CHECK(ojson.dump() != "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json clear wrmsr access log allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json clear wrmsr access log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -819,7 +815,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json clear wrmsr access lo
     CHECK(ojson.dump() == "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json clear wrmsr access log logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json clear wrmsr access log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -838,7 +834,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json clear wrmsr access lo
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json clear wrmsr access log denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json clear wrmsr access log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -856,7 +852,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json clear wrmsr access lo
     CHECK(ojson.dump() != "[\"success\"]");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json wrmsr access log allowed")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json wrmsr access log allowed")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -875,7 +871,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json wrmsr access log allo
     CHECK(ojson.dump() == "{\"0x000000000000002A\":42}");
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json wrmsr access log logged")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json wrmsr access log logged")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);
@@ -895,7 +891,7 @@ TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json wrmsr access log logg
     CHECK(ehlr->m_denials.size() == 1);
 }
 
-TEST_CASE("exit_handler_intel_x64_eapis_wrmsr_vmcall: json wrmsr access log denied")
+TEST_CASE("eapis_exit_handler_wrmsr_vmcall: json wrmsr access log denied")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks, 0x0);

--- a/tests/hve/arch/intel_x64/vmcs/test_ept.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_ept.cpp
@@ -22,17 +22,19 @@
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 #include "../../../../../include/hve/arch/intel_x64/vmcs/ept.h"
 
-constexpr const ept_intel_x64::integer_pointer virt = 0x0000100000000000ULL;
+namespace intel = eapis::hve::intel_x64;
+
+constexpr const intel::ept::integer_pointer virt = 0x0000100000000000ULL;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("ept_intel_x64: add / remove page without touching page settings")
+TEST_CASE("ept: add / remove page without touching page settings")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     eptp->add_page_4k(virt);
     CHECK(eptp->global_size() == 4);
@@ -59,13 +61,13 @@ TEST_CASE("ept_intel_x64: add / remove page without touching page settings")
     CHECK(eptp->global_capacity() == 512 * 1);
 }
 
-TEST_CASE("ept_intel_x64: add / remove page 1g")
+TEST_CASE("ept: add / remove page 1g")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     auto entry1 = eptp->add_page_1g(virt);
     entry1.set_read_access(true);
@@ -100,13 +102,13 @@ TEST_CASE("ept_intel_x64: add / remove page 1g")
     CHECK(eptp->global_capacity() == 512 * 1);
 }
 
-TEST_CASE("ept_intel_x64: add / remove page 2m")
+TEST_CASE("ept: add / remove page 2m")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     auto entry1 = eptp->add_page_2m(virt);
     entry1.set_read_access(true);
@@ -141,13 +143,13 @@ TEST_CASE("ept_intel_x64: add / remove page 2m")
     CHECK(eptp->global_capacity() == 512 * 1);
 }
 
-TEST_CASE("ept_intel_x64: add / remove page 4k")
+TEST_CASE("ept: add / remove page 4k")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     auto entry1 = eptp->add_page_4k(virt);
     entry1.set_read_access(true);
@@ -182,13 +184,13 @@ TEST_CASE("ept_intel_x64: add / remove page 4k")
     CHECK(eptp->global_capacity() == 512 * 1);
 }
 
-TEST_CASE("ept_intel_x64: add / remove page swap")
+TEST_CASE("ept: add / remove page swap")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     auto entry1 = eptp->add_page_4k(virt);
     entry1.set_read_access(true);
@@ -227,25 +229,25 @@ TEST_CASE("ept_intel_x64: add / remove page swap")
     CHECK(eptp->global_capacity() == 512 * 1);
 }
 
-TEST_CASE("ept_intel_x64: add page twice")
+TEST_CASE("ept: add page twice")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     eptp->add_page_4k(virt);
     CHECK_NOTHROW(eptp->add_page_4k(virt));
 }
 
-TEST_CASE("ept_intel_x64: remove page twice")
+TEST_CASE("ept: remove page twice")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     eptp->add_page_4k(virt);
     eptp->add_page_4k(virt + 0x1000);
@@ -257,23 +259,23 @@ TEST_CASE("ept_intel_x64: remove page twice")
     CHECK(eptp->global_size() == 0);
 }
 
-TEST_CASE("ept_intel_x64: remove unknown page")
+TEST_CASE("ept: remove unknown page")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
     CHECK_NOTHROW(eptp->remove_page(virt));
 }
 
-TEST_CASE("ept_intel_x64: invalid gpa_to_epte")
+TEST_CASE("ept: invalid gpa_to_epte")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     eptp->add_page_4k(virt);
 
@@ -283,13 +285,13 @@ TEST_CASE("ept_intel_x64: invalid gpa_to_epte")
     CHECK(eptp->global_size() == 0);
 }
 
-TEST_CASE("ept_intel_x64: valid gpa_to_epte")
+TEST_CASE("ept: valid gpa_to_epte")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     eptp->add_page_4k(virt);
     CHECK_NOTHROW(eptp->gpa_to_epte(virt));
@@ -298,13 +300,13 @@ TEST_CASE("ept_intel_x64: valid gpa_to_epte")
     CHECK(eptp->global_size() == 0);
 }
 
-TEST_CASE("ept_intel_x64: ept_to_mdl")
+TEST_CASE("ept: ept_to_mdl")
 {
     MockRepository mocks;
     setup_mm(mocks);
 
-    ept_intel_x64::integer_pointer scr3 = 0x0ULL;
-    auto eptp = std::make_unique<ept_intel_x64>(&scr3);
+    intel::ept::integer_pointer scr3 = 0x0ULL;
+    auto eptp = std::make_unique<intel::ept>(&scr3);
 
     CHECK(eptp->ept_to_mdl().size() == 1);
     eptp->add_page_1g(0x1000);

--- a/tests/hve/arch/intel_x64/vmcs/test_ept.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_ept.cpp
@@ -19,12 +19,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 #include "../../../../../include/hve/arch/intel_x64/vmcs/ept.h"
 
 constexpr const ept_intel_x64::integer_pointer virt = 0x0000100000000000ULL;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("ept_intel_x64: add / remove page without touching page settings")
 {

--- a/tests/hve/arch/intel_x64/vmcs/test_ept_entry.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_ept_entry.cpp
@@ -19,11 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include <util/bitmanip.h>
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 #include "../../../../../include/hve/arch/intel_x64/vmcs/ept_entry.h"
 
 using epte_type = ept_entry_intel_x64::integer_pointer;
+
 
 TEST_CASE("ept_entry_intel_x64: read access")
 {
@@ -236,3 +239,5 @@ TEST_CASE("ept_entry_intel_x64: clear")
     epte->clear();
     CHECK(entry == 0);
 }
+
+#endif

--- a/tests/hve/arch/intel_x64/vmcs/test_ept_entry.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_ept_entry.cpp
@@ -23,12 +23,14 @@
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 #include "../../../../../include/hve/arch/intel_x64/vmcs/ept_entry.h"
 
-using epte_type = ept_entry_intel_x64::integer_pointer;
+namespace intel = eapis::hve::intel_x64;
 
-TEST_CASE("ept_entry_intel_x64: read access")
+using epte_type = intel::ept_entry::integer_pointer;
+
+TEST_CASE("ept_entry: read access")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_read_access(true);
     CHECK(epte->read_access());
@@ -40,10 +42,10 @@ TEST_CASE("ept_entry_intel_x64: read access")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: write access")
+TEST_CASE("ept_entry: write access")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_write_access(true);
     CHECK(epte->write_access());
@@ -55,10 +57,10 @@ TEST_CASE("ept_entry_intel_x64: write access")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: execute access")
+TEST_CASE("ept_entry: execute access")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_execute_access(true);
     CHECK(epte->execute_access());
@@ -70,10 +72,10 @@ TEST_CASE("ept_entry_intel_x64: execute access")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: memory type")
+TEST_CASE("ept_entry: memory type")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_read_access(true);
     epte->set_write_access(true);
@@ -93,10 +95,10 @@ TEST_CASE("ept_entry_intel_x64: memory type")
     CHECK(epte->memory_type() == 0x0);
 }
 
-TEST_CASE("ept_entry_intel_x64: ignore pat")
+TEST_CASE("ept_entry: ignore pat")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_ignore_pat(true);
     CHECK(epte->ignore_pat());
@@ -108,10 +110,10 @@ TEST_CASE("ept_entry_intel_x64: ignore pat")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: entry type")
+TEST_CASE("ept_entry: entry type")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_entry_type(true);
     CHECK(epte->entry_type());
@@ -123,10 +125,10 @@ TEST_CASE("ept_entry_intel_x64: entry type")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: accessed")
+TEST_CASE("ept_entry: accessed")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_accessed(true);
     CHECK(epte->accessed());
@@ -138,10 +140,10 @@ TEST_CASE("ept_entry_intel_x64: accessed")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: dirty")
+TEST_CASE("ept_entry: dirty")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_dirty(true);
     CHECK(epte->dirty());
@@ -153,10 +155,10 @@ TEST_CASE("ept_entry_intel_x64: dirty")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: execute access user")
+TEST_CASE("ept_entry: execute access user")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_execute_access_user(true);
     CHECK(epte->execute_access_user());
@@ -168,10 +170,10 @@ TEST_CASE("ept_entry_intel_x64: execute access user")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: physical address")
+TEST_CASE("ept_entry: physical address")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_read_access(true);
     epte->set_write_access(true);
@@ -191,10 +193,10 @@ TEST_CASE("ept_entry_intel_x64: physical address")
     CHECK(epte->phys_addr() == 0x0);
 }
 
-TEST_CASE("ept_entry_intel_x64: suppress ve")
+TEST_CASE("ept_entry: suppress ve")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->set_suppress_ve(true);
     CHECK(epte->suppress_ve());
@@ -206,10 +208,10 @@ TEST_CASE("ept_entry_intel_x64: suppress ve")
     CHECK(num_bits_set(entry) == 0);
 }
 
-TEST_CASE("ept_entry_intel_x64: trap on access")
+TEST_CASE("ept_entry: trap on access")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->trap_on_access();
     CHECK(!epte->read_access());
@@ -217,10 +219,10 @@ TEST_CASE("ept_entry_intel_x64: trap on access")
     CHECK(!epte->execute_access());
 }
 
-TEST_CASE("ept_entry_intel_x64: pass through access")
+TEST_CASE("ept_entry: pass through access")
 {
     epte_type entry = 0;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->pass_through_access();
     CHECK(epte->read_access());
@@ -228,10 +230,10 @@ TEST_CASE("ept_entry_intel_x64: pass through access")
     CHECK(epte->execute_access());
 }
 
-TEST_CASE("ept_entry_intel_x64: clear")
+TEST_CASE("ept_entry: clear")
 {
     epte_type entry = 0xFFFFFFFFFFFFFFFF;
-    auto epte = std::make_unique<ept_entry_intel_x64>(&entry);
+    auto epte = std::make_unique<intel::ept_entry>(&entry);
 
     epte->clear();
     CHECK(entry == 0);

--- a/tests/hve/arch/intel_x64/vmcs/test_root_ept.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_root_ept.cpp
@@ -19,6 +19,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 #include "../../../../../include/hve/arch/intel_x64/vmcs/root_ept.h"
 #include "../../../../../include/hve/arch/intel_x64/vmcs/ept_entry.h"
@@ -27,7 +29,6 @@ namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 namespace ept = intel_x64::ept;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("root_ept_intel_x64: eptp")
 {

--- a/tests/hve/arch/intel_x64/vmcs/test_root_ept.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_root_ept.cpp
@@ -23,29 +23,29 @@
 #include "../../../../../include/hve/arch/intel_x64/vmcs/root_ept.h"
 #include "../../../../../include/hve/arch/intel_x64/vmcs/ept_entry.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
+namespace intel = eapis::hve::intel_x64;
+namespace mem_attr = intel_x64::ept::memory_attr;
 namespace ept = intel_x64::ept;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("root_ept_intel_x64: eptp")
+TEST_CASE("root_ept: eptp")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK(root_ept.eptp() == 0x0000000ABCDEF0007);
 }
 
-TEST_CASE("root_ept_intel_x64: map 1g read / write")
+TEST_CASE("root_ept: map 1g read / write")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_uc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::rw_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -56,7 +56,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read / write")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_wc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::rw_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -67,7 +67,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read / write")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_wt);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::rw_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -78,7 +78,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read / write")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_wp);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::rw_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -89,7 +89,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read / write")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_wb);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::rw_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -100,14 +100,14 @@ TEST_CASE("root_ept_intel_x64: map 1g read / write")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 1g read / execute")
+TEST_CASE("root_ept: map 1g read / execute")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_uc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::re_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -118,7 +118,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read / execute")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_wc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::re_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -129,7 +129,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read / execute")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_wt);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::re_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -140,7 +140,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read / execute")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_wp);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::re_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -151,7 +151,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read / execute")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_wb);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::re_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -162,14 +162,14 @@ TEST_CASE("root_ept_intel_x64: map 1g read / execute")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 1g read only")
+TEST_CASE("root_ept: map 1g read only")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::ro_uc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::ro_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -180,7 +180,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read only")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::ro_wc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::ro_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -191,7 +191,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read only")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::ro_wt);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::ro_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -202,7 +202,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read only")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::ro_wp);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::ro_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -213,7 +213,7 @@ TEST_CASE("root_ept_intel_x64: map 1g read only")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::ro_wb);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::ro_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -224,14 +224,14 @@ TEST_CASE("root_ept_intel_x64: map 1g read only")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 1g execute only")
+TEST_CASE("root_ept: map 1g execute only")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_uc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::eo_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -242,7 +242,7 @@ TEST_CASE("root_ept_intel_x64: map 1g execute only")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_wc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::eo_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -253,7 +253,7 @@ TEST_CASE("root_ept_intel_x64: map 1g execute only")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_wt);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::eo_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -264,7 +264,7 @@ TEST_CASE("root_ept_intel_x64: map 1g execute only")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_wp);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::eo_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -275,7 +275,7 @@ TEST_CASE("root_ept_intel_x64: map 1g execute only")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_wb);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::eo_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -286,14 +286,14 @@ TEST_CASE("root_ept_intel_x64: map 1g execute only")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 1g pass through")
+TEST_CASE("root_ept: map 1g pass through")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_uc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::pt_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -304,7 +304,7 @@ TEST_CASE("root_ept_intel_x64: map 1g pass through")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_wc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::pt_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -315,7 +315,7 @@ TEST_CASE("root_ept_intel_x64: map 1g pass through")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_wt);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::pt_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -326,7 +326,7 @@ TEST_CASE("root_ept_intel_x64: map 1g pass through")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_wp);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::pt_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -337,7 +337,7 @@ TEST_CASE("root_ept_intel_x64: map 1g pass through")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_wb);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::pt_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -348,14 +348,14 @@ TEST_CASE("root_ept_intel_x64: map 1g pass through")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 1g trap")
+TEST_CASE("root_ept: map 1g trap")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_uc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::tp_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -366,7 +366,7 @@ TEST_CASE("root_ept_intel_x64: map 1g trap")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_wc);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::tp_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -377,7 +377,7 @@ TEST_CASE("root_ept_intel_x64: map 1g trap")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_wt);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::tp_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -388,7 +388,7 @@ TEST_CASE("root_ept_intel_x64: map 1g trap")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_wp);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::tp_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -399,7 +399,7 @@ TEST_CASE("root_ept_intel_x64: map 1g trap")
     }
 
     {
-        root_ept.map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_wb);
+        root_ept.map_1g(0x1000UL, 0x1000UL, mem_attr::tp_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -410,14 +410,14 @@ TEST_CASE("root_ept_intel_x64: map 1g trap")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 2m read / write")
+TEST_CASE("root_ept: map 2m read / write")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_uc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::rw_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -428,7 +428,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read / write")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_wc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::rw_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -439,7 +439,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read / write")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_wt);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::rw_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -450,7 +450,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read / write")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_wp);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::rw_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -461,7 +461,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read / write")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_wb);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::rw_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -472,14 +472,14 @@ TEST_CASE("root_ept_intel_x64: map 2m read / write")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 2m read / execute")
+TEST_CASE("root_ept: map 2m read / execute")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_uc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::re_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -490,7 +490,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read / execute")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_wc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::re_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -501,7 +501,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read / execute")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_wt);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::re_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -512,7 +512,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read / execute")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_wp);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::re_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -523,7 +523,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read / execute")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_wb);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::re_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -534,14 +534,14 @@ TEST_CASE("root_ept_intel_x64: map 2m read / execute")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 2m read only")
+TEST_CASE("root_ept: map 2m read only")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::ro_uc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::ro_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -552,7 +552,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read only")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::ro_wc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::ro_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -563,7 +563,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read only")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::ro_wt);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::ro_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -574,7 +574,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read only")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::ro_wp);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::ro_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -585,7 +585,7 @@ TEST_CASE("root_ept_intel_x64: map 2m read only")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::ro_wb);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::ro_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -596,13 +596,13 @@ TEST_CASE("root_ept_intel_x64: map 2m read only")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 2m execute only")
+TEST_CASE("root_ept: map 2m execute only")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_uc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::eo_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -613,7 +613,7 @@ TEST_CASE("root_ept_intel_x64: map 2m execute only")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_wc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::eo_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -624,7 +624,7 @@ TEST_CASE("root_ept_intel_x64: map 2m execute only")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_wt);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::eo_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -635,7 +635,7 @@ TEST_CASE("root_ept_intel_x64: map 2m execute only")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_wp);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::eo_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -646,7 +646,7 @@ TEST_CASE("root_ept_intel_x64: map 2m execute only")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_wb);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::eo_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -657,13 +657,13 @@ TEST_CASE("root_ept_intel_x64: map 2m execute only")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 2m pass through")
+TEST_CASE("root_ept: map 2m pass through")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_uc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::pt_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -674,7 +674,7 @@ TEST_CASE("root_ept_intel_x64: map 2m pass through")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_wc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::pt_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -685,7 +685,7 @@ TEST_CASE("root_ept_intel_x64: map 2m pass through")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_wt);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::pt_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -696,7 +696,7 @@ TEST_CASE("root_ept_intel_x64: map 2m pass through")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_wp);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::pt_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -707,7 +707,7 @@ TEST_CASE("root_ept_intel_x64: map 2m pass through")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_wb);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::pt_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -718,14 +718,14 @@ TEST_CASE("root_ept_intel_x64: map 2m pass through")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 2m trap")
+TEST_CASE("root_ept: map 2m trap")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_uc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::tp_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -736,7 +736,7 @@ TEST_CASE("root_ept_intel_x64: map 2m trap")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_wc);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::tp_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -747,7 +747,7 @@ TEST_CASE("root_ept_intel_x64: map 2m trap")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_wt);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::tp_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -758,7 +758,7 @@ TEST_CASE("root_ept_intel_x64: map 2m trap")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_wp);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::tp_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -769,7 +769,7 @@ TEST_CASE("root_ept_intel_x64: map 2m trap")
     }
 
     {
-        root_ept.map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_wb);
+        root_ept.map_2m(0x1000UL, 0x1000UL, mem_attr::tp_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -780,14 +780,14 @@ TEST_CASE("root_ept_intel_x64: map 2m trap")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 4k read / write")
+TEST_CASE("root_ept: map 4k read / write")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_uc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::rw_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -798,7 +798,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read / write")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_wc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::rw_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -809,7 +809,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read / write")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_wt);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::rw_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -820,7 +820,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read / write")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_wp);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::rw_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -831,7 +831,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read / write")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_wb);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::rw_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -842,13 +842,13 @@ TEST_CASE("root_ept_intel_x64: map 4k read / write")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 4k read / execute")
+TEST_CASE("root_ept: map 4k read / execute")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_uc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::re_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -859,7 +859,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read / execute")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_wc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::re_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -870,7 +870,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read / execute")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_wt);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::re_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -881,7 +881,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read / execute")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_wp);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::re_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -892,7 +892,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read / execute")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_wb);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::re_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -903,14 +903,14 @@ TEST_CASE("root_ept_intel_x64: map 4k read / execute")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 4k read only")
+TEST_CASE("root_ept: map 4k read only")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::ro_uc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::ro_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -921,7 +921,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read only")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::ro_wc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::ro_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -932,7 +932,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read only")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::ro_wt);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::ro_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -943,7 +943,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read only")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::ro_wp);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::ro_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -954,7 +954,7 @@ TEST_CASE("root_ept_intel_x64: map 4k read only")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::ro_wb);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::ro_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(!entry.write_access());
@@ -965,14 +965,14 @@ TEST_CASE("root_ept_intel_x64: map 4k read only")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 4k execute only")
+TEST_CASE("root_ept: map 4k execute only")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_uc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::eo_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -983,7 +983,7 @@ TEST_CASE("root_ept_intel_x64: map 4k execute only")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_wc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::eo_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -994,7 +994,7 @@ TEST_CASE("root_ept_intel_x64: map 4k execute only")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_wt);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::eo_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -1005,7 +1005,7 @@ TEST_CASE("root_ept_intel_x64: map 4k execute only")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_wp);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::eo_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -1016,7 +1016,7 @@ TEST_CASE("root_ept_intel_x64: map 4k execute only")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_wb);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::eo_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -1027,14 +1027,14 @@ TEST_CASE("root_ept_intel_x64: map 4k execute only")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 4k pass through")
+TEST_CASE("root_ept: map 4k pass through")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_uc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::pt_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -1045,7 +1045,7 @@ TEST_CASE("root_ept_intel_x64: map 4k pass through")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::pt_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -1056,7 +1056,7 @@ TEST_CASE("root_ept_intel_x64: map 4k pass through")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wt);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::pt_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -1067,7 +1067,7 @@ TEST_CASE("root_ept_intel_x64: map 4k pass through")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wp);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::pt_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -1078,7 +1078,7 @@ TEST_CASE("root_ept_intel_x64: map 4k pass through")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wb);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::pt_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(entry.read_access());
         CHECK(entry.write_access());
@@ -1089,14 +1089,14 @@ TEST_CASE("root_ept_intel_x64: map 4k pass through")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map 4k trap")
+TEST_CASE("root_ept: map 4k trap")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_uc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::tp_uc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -1107,7 +1107,7 @@ TEST_CASE("root_ept_intel_x64: map 4k trap")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_wc);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::tp_wc);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -1118,7 +1118,7 @@ TEST_CASE("root_ept_intel_x64: map 4k trap")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_wt);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::tp_wt);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -1129,7 +1129,7 @@ TEST_CASE("root_ept_intel_x64: map 4k trap")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_wp);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::tp_wp);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -1140,7 +1140,7 @@ TEST_CASE("root_ept_intel_x64: map 4k trap")
     }
 
     {
-        root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_wb);
+        root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::tp_wb);
         auto entry = root_ept.gpa_to_epte(0x1000UL);
         CHECK(!entry.read_access());
         CHECK(!entry.write_access());
@@ -1151,33 +1151,33 @@ TEST_CASE("root_ept_intel_x64: map 4k trap")
     }
 }
 
-TEST_CASE("root_ept_intel_x64: map invalid")
+TEST_CASE("root_ept: map invalid")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK_THROWS(root_ept.map_page(0x0, 0x0, 0x0, 0x0));
     CHECK_THROWS(root_ept.map_page(0x0, 0x0, 0x0, ept::pt::size_bytes));
 }
 
-TEST_CASE("root_ept_intel_x64: map / unmap twice")
+TEST_CASE("root_ept: map / unmap twice")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
-    CHECK_NOTHROW(root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wb));
-    CHECK_NOTHROW(root_ept.map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wb));
+    CHECK_NOTHROW(root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::pt_wb));
+    CHECK_NOTHROW(root_ept.map_4k(0x1000UL, 0x1000UL, mem_attr::pt_wb));
     CHECK_NOTHROW(root_ept.unmap(0x1000UL));
     CHECK_NOTHROW(root_ept.unmap(0x1000UL));
 }
 
-TEST_CASE("root_ept_intel_x64: setup_identity_map_1g invalid")
+TEST_CASE("root_ept: setup_identity_map_1g invalid")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK_THROWS(root_ept.setup_identity_map_1g(0x1, 0x40000000));
     CHECK_THROWS(root_ept.setup_identity_map_1g(0x0, 0x40000001));
@@ -1185,21 +1185,21 @@ TEST_CASE("root_ept_intel_x64: setup_identity_map_1g invalid")
     CHECK_THROWS(root_ept.unmap_identity_map_1g(0x0, 0x40000001));
 }
 
-TEST_CASE("root_ept_intel_x64: setup_identity_map_1g valid")
+TEST_CASE("root_ept: setup_identity_map_1g valid")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK_NOTHROW(root_ept.setup_identity_map_1g(0x0, 0x40000000));
     CHECK_NOTHROW(root_ept.unmap_identity_map_1g(0x0, 0x40000000));
 }
 
-TEST_CASE("root_ept_intel_x64: setup_identity_map_2m invalid")
+TEST_CASE("root_ept: setup_identity_map_2m invalid")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK_THROWS(root_ept.setup_identity_map_2m(0x1, 0x200000));
     CHECK_THROWS(root_ept.setup_identity_map_2m(0x0, 0x200001));
@@ -1207,21 +1207,21 @@ TEST_CASE("root_ept_intel_x64: setup_identity_map_2m invalid")
     CHECK_THROWS(root_ept.unmap_identity_map_2m(0x0, 0x200001));
 }
 
-TEST_CASE("root_ept_intel_x64: setup_identity_map_2m valid")
+TEST_CASE("root_ept: setup_identity_map_2m valid")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK_NOTHROW(root_ept.setup_identity_map_2m(0x0, 0x200000));
     CHECK_NOTHROW(root_ept.unmap_identity_map_2m(0x0, 0x200000));
 }
 
-TEST_CASE("root_ept_intel_x64: setup_identity_map_4k invalid")
+TEST_CASE("root_ept: setup_identity_map_4k invalid")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK_THROWS(root_ept.setup_identity_map_4k(0x1, 0x1000));
     CHECK_THROWS(root_ept.setup_identity_map_4k(0x0, 0x1001));
@@ -1229,21 +1229,21 @@ TEST_CASE("root_ept_intel_x64: setup_identity_map_4k invalid")
     CHECK_THROWS(root_ept.unmap_identity_map_4k(0x0, 0x1001));
 }
 
-TEST_CASE("root_ept_intel_x64: setup_identity_map_4k valid")
+TEST_CASE("root_ept: setup_identity_map_4k valid")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK_NOTHROW(root_ept.setup_identity_map_4k(0x0, 0x1000));
     CHECK_NOTHROW(root_ept.unmap_identity_map_4k(0x0, 0x1000));
 }
 
-TEST_CASE("root_ept_intel_x64: ept_to_mdl")
+TEST_CASE("root_ept: ept_to_mdl")
 {
     MockRepository mocks;
     setup_mm(mocks);
-    root_ept_intel_x64 root_ept{};
+    intel::root_ept root_ept{};
 
     CHECK_NOTHROW(root_ept.ept_to_mdl());
 }

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs.cpp
@@ -21,22 +21,22 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
+namespace intel = bfvmm::intel_x64;
+namespace vmcs_eapis = eapis::hve::intel_x64::vmcs;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("vmcs_intel_x64_eapis: construction / destruction")
+TEST_CASE("eapis_vmcs: construction / destruction")
 {
-    CHECK_NOTHROW(std::make_unique<vmcs_intel_x64_eapis>());
+    CHECK_NOTHROW(std::make_unique<vmcs_eapis::vmcs>());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis: launch")
+TEST_CASE("eapis_vmcs: launch")
 {
     MockRepository mocks;
     setup_mm(mocks);
     auto vmcs = setup_vmcs(mocks);
-    auto vmss = std::make_unique<vmcs_intel_x64_state>();
+    auto vmss = std::make_unique<intel::vmcs_state>();
 
     vmcs->launch(vmss.get(), vmss.get());
 }

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs.cpp
@@ -19,12 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("vmcs_intel_x64_eapis: construction / destruction")
 {

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_cr.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_cr.cpp
@@ -21,34 +21,31 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr0 load hook")
+TEST_CASE("eapis_vmcs_cr: enable cr0 load hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
     auto vmcs = setup_vmcs(mocks);
 
     vmcs->enable_cr0_load_hook(42ULL, 42ULL);
-    CHECK(vmcs::cr0_guest_host_mask::get() == 42ULL);
-    CHECK(vmcs::cr0_read_shadow::get() == 42ULL);
+    CHECK(::intel_x64::vmcs::cr0_guest_host_mask::get() == 42ULL);
+    CHECK(::intel_x64::vmcs::cr0_read_shadow::get() == 42ULL);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr0 load hook")
+TEST_CASE("eapis_vmcs_cr: disable cr0 load hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
     auto vmcs = setup_vmcs(mocks);
 
     vmcs->disable_cr0_load_hook();
-    CHECK(vmcs::cr0_guest_host_mask::get() == 0ULL);
-    CHECK(vmcs::cr0_read_shadow::get() == 0ULL);
+    CHECK(::intel_x64::vmcs::cr0_guest_host_mask::get() == 0ULL);
+    CHECK(::intel_x64::vmcs::cr0_read_shadow::get() == 0ULL);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr3 load hook")
+TEST_CASE("eapis_vmcs_cr: enable cr3 load hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -58,7 +55,7 @@ TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr3 load hook")
     CHECK(proc_ctls::cr3_load_exiting::is_enabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr3 load hook")
+TEST_CASE("eapis_vmcs_cr: disable cr3 load hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -68,7 +65,7 @@ TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr3 load hook")
     CHECK(proc_ctls::cr3_load_exiting::is_disabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr3 store hook")
+TEST_CASE("eapis_vmcs_cr: enable cr3 store hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -78,7 +75,7 @@ TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr3 store hook")
     CHECK(proc_ctls::cr3_store_exiting::is_enabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr3 store hook")
+TEST_CASE("eapis_vmcs_cr: disable cr3 store hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -88,29 +85,29 @@ TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr3 store hook")
     CHECK(proc_ctls::cr3_store_exiting::is_disabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr4 load hook")
+TEST_CASE("eapis_vmcs_cr: enable cr4 load hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
     auto vmcs = setup_vmcs(mocks);
 
     vmcs->enable_cr4_load_hook(42ULL, 42ULL);
-    CHECK(vmcs::cr4_guest_host_mask::get() == 42ULL);
-    CHECK(vmcs::cr4_read_shadow::get() == 42ULL);
+    CHECK(::intel_x64::vmcs::cr4_guest_host_mask::get() == 42ULL);
+    CHECK(::intel_x64::vmcs::cr4_read_shadow::get() == 42ULL);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr4 load hook")
+TEST_CASE("eapis_vmcs_cr: disable cr4 load hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
     auto vmcs = setup_vmcs(mocks);
 
     vmcs->disable_cr4_load_hook();
-    CHECK(vmcs::cr4_guest_host_mask::get() == 0ULL);
-    CHECK(vmcs::cr4_read_shadow::get() == 0ULL);
+    CHECK(::intel_x64::vmcs::cr4_guest_host_mask::get() == 0ULL);
+    CHECK(::intel_x64::vmcs::cr4_read_shadow::get() == 0ULL);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr8 load hook")
+TEST_CASE("eapis_vmcs_cr: enable cr8 load hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -120,7 +117,7 @@ TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr8 load hook")
     CHECK(proc_ctls::cr8_load_exiting::is_enabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr8 load hook")
+TEST_CASE("eapis_vmcs_cr: disable cr8 load hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -130,7 +127,7 @@ TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr8 load hook")
     CHECK(proc_ctls::cr8_load_exiting::is_disabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr8 store hook")
+TEST_CASE("eapis_vmcs_cr: enable cr8 store hook")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -140,7 +137,7 @@ TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr8 store hook")
     CHECK(proc_ctls::cr8_store_exiting::is_enabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_cr: disable cr8 store hook")
+TEST_CASE("eapis_vmcs_cr: disable cr8 store hook")
 {
     MockRepository mocks;
     setup_mm(mocks);

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_cr.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_cr.cpp
@@ -19,12 +19,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("vmcs_intel_x64_eapis_cr: enable cr0 load hook")
 {

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_ept.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_ept.cpp
@@ -21,43 +21,42 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
+namespace ept_p = ::intel_x64::vmcs::ept_pointer;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("vmcs_intel_x64_eapis_ept: enable ept")
+TEST_CASE("eapis_vmcs_ept: enable ept")
 {
     MockRepository mocks;
     setup_mm(mocks);
     auto vmcs = setup_vmcs(mocks);
 
     vmcs->enable_ept(0x0000000ABCDEF0000);
-    CHECK(vmcs::ept_pointer::memory_type::get() == vmcs::ept_pointer::memory_type::write_back);
-    CHECK(vmcs::ept_pointer::page_walk_length_minus_one::get() == 3UL);
-    CHECK(vmcs::ept_pointer::phys_addr::get() == 0x0000000ABCDEF0000);
+    CHECK(ept_p::memory_type::get() == ept_p::memory_type::write_back);
+    CHECK(ept_p::page_walk_length_minus_one::get() == 3UL);
+    CHECK(ept_p::phys_addr::get() == 0x0000000ABCDEF0000);
     CHECK(proc_ctls2::enable_ept::is_enabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_ept: disable ept")
+TEST_CASE("eapis_vmcs_ept: disable ept")
 {
     MockRepository mocks;
     setup_mm(mocks);
     auto vmcs = setup_vmcs(mocks);
 
     vmcs->disable_ept();
-    CHECK(vmcs::ept_pointer::get() == 0);
+    CHECK(ept_p::get() == 0);
     CHECK(proc_ctls2::enable_ept::is_disabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_ept: set eptp")
+TEST_CASE("eapis_vmcs_ept: set eptp")
 {
     MockRepository mocks;
     setup_mm(mocks);
     auto vmcs = setup_vmcs(mocks);
 
     vmcs->set_eptp(0x0000000ABCDEF0000);
-    CHECK(vmcs::ept_pointer::phys_addr::get() == 0x0000000ABCDEF0000);
+    CHECK(ept_p::phys_addr::get() == 0x0000000ABCDEF0000);
 }
 
 #endif

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_ept.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_ept.cpp
@@ -19,12 +19,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("vmcs_intel_x64_eapis_ept: enable ept")
 {

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_io.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_io.cpp
@@ -19,13 +19,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 namespace proc_ctls = vmcs::primary_processor_based_vm_execution_controls;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("vmcs_intel_x64_eapis_io: enable io bitmaps")
 {

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_io.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_io.cpp
@@ -21,13 +21,11 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
-namespace proc_ctls = vmcs::primary_processor_based_vm_execution_controls;
+namespace proc_ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("vmcs_intel_x64_eapis_io: enable io bitmaps")
+TEST_CASE("eapis_vmcs_io: enable io bitmaps")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -41,12 +39,12 @@ TEST_CASE("vmcs_intel_x64_eapis_io: enable io bitmaps")
     CHECK(vmcs->m_io_bitmapa_view.size() == static_cast<std::ptrdiff_t>(x64::page_size));
     CHECK(vmcs->m_io_bitmapb_view.data() != nullptr);
     CHECK(vmcs->m_io_bitmapb_view.size() == static_cast<std::ptrdiff_t>(x64::page_size));
-    CHECK(vmcs::address_of_io_bitmap_a::get() != 0);
-    CHECK(vmcs::address_of_io_bitmap_b::get() != 0);
+    CHECK(::intel_x64::vmcs::address_of_io_bitmap_a::get() != 0);
+    CHECK(::intel_x64::vmcs::address_of_io_bitmap_b::get() != 0);
     CHECK(proc_ctls::use_io_bitmaps::is_enabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_io: disable io bitmaps")
+TEST_CASE("eapis_vmcs_io: disable io bitmaps")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -60,12 +58,12 @@ TEST_CASE("vmcs_intel_x64_eapis_io: disable io bitmaps")
     CHECK(vmcs->m_io_bitmapa_view.empty());
     CHECK(vmcs->m_io_bitmapb_view.data() == nullptr);
     CHECK(vmcs->m_io_bitmapb_view.empty());
-    CHECK(vmcs::address_of_io_bitmap_a::get() == 0);
-    CHECK(vmcs::address_of_io_bitmap_b::get() == 0);
+    CHECK(::intel_x64::vmcs::address_of_io_bitmap_a::get() == 0);
+    CHECK(::intel_x64::vmcs::address_of_io_bitmap_b::get() == 0);
     CHECK(proc_ctls::use_io_bitmaps::is_disabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_io: trap on io access")
+TEST_CASE("eapis_vmcs_io: trap on io access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -81,7 +79,7 @@ TEST_CASE("vmcs_intel_x64_eapis_io: trap on io access")
     CHECK(vmcs->m_io_bitmapb_view[8] == 0x4);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_io: trap on all io accesses")
+TEST_CASE("eapis_vmcs_io: trap on all io accesses")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -107,7 +105,7 @@ TEST_CASE("vmcs_intel_x64_eapis_io: trap on all io accesses")
     CHECK(all_setb == 0xFF);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_io: pass through io access")
+TEST_CASE("eapis_vmcs_io: pass through io access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -124,7 +122,7 @@ TEST_CASE("vmcs_intel_x64_eapis_io: pass through io access")
     CHECK(vmcs->m_io_bitmapb_view[8] == 0xFB);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_io: pass through all io accesses")
+TEST_CASE("eapis_vmcs_io: pass through all io accesses")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -150,7 +148,7 @@ TEST_CASE("vmcs_intel_x64_eapis_io: pass through all io accesses")
     CHECK(all_setb == 0x0);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_io: whitelist io access")
+TEST_CASE("eapis_vmcs_io: whitelist io access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -164,7 +162,7 @@ TEST_CASE("vmcs_intel_x64_eapis_io: whitelist io access")
     CHECK(vmcs->m_io_bitmapb_view[8] == 0xFB);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_io: blacklist io access")
+TEST_CASE("eapis_vmcs_io: blacklist io access")
 {
     MockRepository mocks;
     setup_mm(mocks);

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_msr.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_msr.cpp
@@ -19,9 +19,10 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("vmcs_intel_x64_eapis_msr: enable msr bitmap")
 {

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_msr.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_msr.cpp
@@ -21,9 +21,11 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
+namespace msr_bitmap_address = ::intel_x64::vmcs::address_of_msr_bitmap;
+
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: enable msr bitmap")
+TEST_CASE("eapis_vmcs_msr: enable msr bitmap")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -34,11 +36,11 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: enable msr bitmap")
     CHECK(vmcs->m_msr_bitmap != nullptr);
     CHECK(vmcs->m_msr_bitmap_view.data() != nullptr);
     CHECK(vmcs->m_msr_bitmap_view.size() == static_cast<std::ptrdiff_t>(x64::page_size));
-    CHECK(vmcs::address_of_msr_bitmap::get() != 0);
+    CHECK(msr_bitmap_address::get() != 0);
     CHECK(proc_ctls::use_msr_bitmap::is_enabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: disable msr bitmap")
+TEST_CASE("eapis_vmcs_msr: disable msr bitmap")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -49,11 +51,11 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: disable msr bitmap")
     CHECK(vmcs->m_msr_bitmap == nullptr);
     CHECK(vmcs->m_msr_bitmap_view.data() == nullptr);
     CHECK(vmcs->m_msr_bitmap_view.empty());
-    CHECK(vmcs::address_of_msr_bitmap::get() == 0);
+    CHECK(msr_bitmap_address::get() == 0);
     CHECK(proc_ctls::use_msr_bitmap::is_disabled());
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: trap on read msr access")
+TEST_CASE("eapis_vmcs_msr: trap on read msr access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -72,7 +74,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: trap on read msr access")
     CHECK_THROWS(vmcs->trap_on_rdmsr_access(0xC0004000UL));
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: trap on all read msr accesses")
+TEST_CASE("eapis_vmcs_msr: trap on all read msr accesses")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -98,7 +100,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: trap on all read msr accesses")
     CHECK(all_set_0 == 0x0);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: pass through read msr access")
+TEST_CASE("eapis_vmcs_msr: pass through read msr access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -119,7 +121,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: pass through read msr access")
     CHECK_THROWS(vmcs->pass_through_rdmsr_access(0xC0004000UL));
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: pass through all read msr accesses")
+TEST_CASE("eapis_vmcs_msr: pass through all read msr accesses")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -147,7 +149,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: pass through all read msr accesses")
     CHECK(all_set_1 == 0xFF);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: whitelist read msr access")
+TEST_CASE("eapis_vmcs_msr: whitelist read msr access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -162,7 +164,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: whitelist read msr access")
     CHECK(vmcs->m_msr_bitmap_view[0x408] == 0xFB);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: black list read msr access")
+TEST_CASE("eapis_vmcs_msr: black list read msr access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -177,7 +179,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: black list read msr access")
     CHECK(vmcs->m_msr_bitmap_view[0x408] == 0x4);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: trap on write msr access")
+TEST_CASE("eapis_vmcs_msr: trap on write msr access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -196,7 +198,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: trap on write msr access")
     CHECK_THROWS(vmcs->trap_on_wrmsr_access(0xC0004000UL));
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: trap on all write msr accesses")
+TEST_CASE("eapis_vmcs_msr: trap on all write msr accesses")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -222,7 +224,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: trap on all write msr accesses")
     CHECK(all_set_0 == 0x0);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: pass through write msr access")
+TEST_CASE("eapis_vmcs_msr: pass through write msr access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -243,7 +245,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: pass through write msr access")
     CHECK_THROWS(vmcs->pass_through_wrmsr_access(0xC0004000UL));
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: pass through all write msr accesses")
+TEST_CASE("eapis_vmcs_msr: pass through all write msr accesses")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -271,7 +273,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: pass through all write msr accesses")
     CHECK(all_set_1 == 0xFF);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: whitelist write msr access")
+TEST_CASE("eapis_vmcs_msr: whitelist write msr access")
 {
     MockRepository mocks;
     setup_mm(mocks);
@@ -286,7 +288,7 @@ TEST_CASE("vmcs_intel_x64_eapis_msr: whitelist write msr access")
     CHECK(vmcs->m_msr_bitmap_view[0xC08] == 0xFB);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_msr: blacklist write msr access")
+TEST_CASE("eapis_vmcs_msr: blacklist write msr access")
 {
     MockRepository mocks;
     setup_mm(mocks);

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_vpid.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_vpid.cpp
@@ -21,12 +21,11 @@
 
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
-namespace intel = intel_x64;
-namespace vmcs = intel_x64::vmcs;
+namespace vpi = ::intel_x64::vmcs::virtual_processor_identifier;
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-TEST_CASE("vmcs_intel_x64_eapis_vpid: enable vpid")
+TEST_CASE("eapis_vmcs_vpid: enable vpid")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks);
@@ -34,10 +33,10 @@ TEST_CASE("vmcs_intel_x64_eapis_vpid: enable vpid")
     vmcs->enable_vpid();
 
     CHECK(proc_ctls2::enable_vpid::is_enabled());
-    CHECK(vmcs::virtual_processor_identifier::get() != 0);
+    CHECK(vpi::get() != 0);
 }
 
-TEST_CASE("vmcs_intel_x64_eapis_vpid: disable vpid")
+TEST_CASE("eapis_vmcs_vpid: disable vpid")
 {
     MockRepository mocks;
     auto vmcs = setup_vmcs(mocks);
@@ -45,7 +44,7 @@ TEST_CASE("vmcs_intel_x64_eapis_vpid: disable vpid")
     vmcs->disable_vpid();
 
     CHECK(proc_ctls2::enable_vpid::is_disabled());
-    CHECK(vmcs::virtual_processor_identifier::get() == 0);
+    CHECK(vpi::get() == 0);
 }
 
 #endif

--- a/tests/hve/arch/intel_x64/vmcs/test_vmcs_vpid.cpp
+++ b/tests/hve/arch/intel_x64/vmcs/test_vmcs_vpid.cpp
@@ -19,12 +19,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include "../../../../../include/support/arch/intel_x64/test_support.h"
 
 namespace intel = intel_x64;
 namespace vmcs = intel_x64::vmcs;
 
-#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 TEST_CASE("vmcs_intel_x64_eapis_vpid: enable vpid")
 {

--- a/tests/util/test_bitmanip.cpp
+++ b/tests/util/test_bitmanip.cpp
@@ -19,6 +19,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
 #include <catch/catch.hpp>
 #include "../../include/util/bitmanip.h"
 
@@ -88,3 +90,4 @@ TEST_CASE("bitmanip_eapis: is bit")
     CHECK_THROWS(is_bit_set_from_span(buf_view, 1000000));
     CHECK_THROWS(is_bit_cleared_from_span(buf_view, 1000000));
 }
+#endif


### PR DESCRIPTION
Altered class names to remove "_intel_x64" and "_eapis" names and put that information in namespaces. 