### PR TITLE
Moved ACPI struct architecture from hypervisor repo to EAPIS

### DIFF
--- a/include/acpi/acpi.h
+++ b/include/acpi/acpi.h
@@ -1,0 +1,315 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef ACPI_INTEL_X64_EAPIS_H
+#define ACPI_INTEL_X64_EAPIS_H
+
+#include <set>
+#include <intrinsics.h>
+
+// *INDENT-OFF*
+
+// -----------------------------------------------------------------------------
+// Exports
+// -----------------------------------------------------------------------------
+
+#include <bfexports.h>
+
+namespace eapis
+{
+namespace acpi
+{
+
+using acpi_ptr = uint8_t *;
+
+struct acpi_header {
+    char signature[5] = { ' ', ' ', ' ', ' ', '\0' };
+    uint32_t length = 0;
+    uint8_t revision = 0;
+    uint8_t checksum = 1;
+    char oem_id[7] = { ' ', ' ', ' ', ' ', ' ', ' ', '\0' };
+    char oem_table_id[9] = { ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '\0' };
+    uint32_t oem_revision = 0;
+    char creator_id[5] = { ' ', ' ', ' ', ' ', '\0' };
+    uint32_t creator_revision = 0;
+
+    acpi_header() = default;
+    acpi_header(acpi_ptr base)
+    {
+        memcpy(&signature, base, 4);
+        length = ::acpi::read_uint32(base + 4);
+        memcpy(&revision, base + 8, 1);
+        memcpy(&checksum, base + 9, 1);
+        memcpy(oem_id, base + 10, 6);
+        memcpy(&oem_table_id, base + 16, 8);
+        oem_revision = ::acpi::read_uint32(base + 24);
+        memcpy(&creator_id, base + 28, 4);
+        creator_revision = ::acpi::read_uint32(base + 32);
+    }
+};
+
+struct ics_header {
+    uint8_t type = 0;
+    uint8_t length = 0;
+
+    ics_header() = default;
+    ics_header(acpi_ptr base)
+    {
+        memcpy(&type, base, 1);
+        memcpy(&length, base + 1, 1);
+    }
+};
+
+struct local_apic {
+    acpi_ptr base = NULL;
+    ics_header header;
+    uint8_t acpi_uid = 0;
+    uint8_t apic_id = 0;
+    uint32_t flags = 0;
+
+    local_apic() = default;
+    local_apic(acpi_ptr b)
+    {
+        base = b;
+        header = ics_header(base);
+        memcpy(&acpi_uid, base + 2, 1);
+        memcpy(&apic_id, base + 3, 1);
+        flags = ::acpi::read_uint32(base + 4);
+    }
+
+    bool operator<(const local_apic& rhs) const
+    { return acpi_uid < rhs.acpi_uid; }
+
+    bool operator==(const local_apic& rhs) const
+    { return acpi_uid == rhs.acpi_uid; }
+
+    bool is_enabled()
+    { return (flags & 0x1U); }
+};
+
+struct io_apic {
+    acpi_ptr base = NULL;
+    ics_header header;
+    uint8_t io_apic_id = 0;
+    uint32_t io_apic_address = 0;
+    uint32_t global_interrupt_base = 0;
+
+    io_apic() = default;
+    io_apic(acpi_ptr b)
+    {
+        base = b;
+        header = ics_header(base);
+        memcpy(&io_apic_id, base + 2, 1);
+        // Empty reserved bit at base + 3
+        io_apic_address = ::acpi::read_uint32(base + 4);
+        global_interrupt_base = ::acpi::read_uint32(base + 8);
+    }
+
+    bool operator<(const io_apic& rhs) const
+    { return io_apic_id < rhs.io_apic_id; }
+
+    bool operator==(const io_apic& rhs) const
+    { return io_apic_id == rhs.io_apic_id; }
+};
+
+struct madt {
+    enum ics_type : uint32_t {
+        LAPIC,
+        IOAPIC,
+        INTERRUPT_SOURCE_OVERRIDE,
+        NMI,
+        LAPIC_NMI,
+        LAPIC_ADDRESS_OVERRIDE,
+        IOSAPIC,
+        LSAPIC,
+        PLATFORM_INTERRUPT_SOURCES,
+        X2_LAPIC_NMI,
+        GICC,
+        GICD,
+        GIC_MSI_FRAME,
+        GICR,
+        GIC_ITS
+    };
+
+    acpi_ptr base;
+    acpi_header header;
+    uint32_t local_interrupt_address;
+    uint32_t flags;
+    acpi_ptr ics;
+
+    madt() = default;
+    madt(acpi_ptr b)
+    {
+        base = b;
+        header = acpi_header(base);
+        local_interrupt_address = ::acpi::read_uint32(base + 36);
+        flags = ::acpi::read_uint32(base + 40);
+        ics = base + 44;
+    }
+
+    bool is_pcat_compatible()
+    { return (flags & 0x1U); }
+
+    std::set<local_apic> get_lapic_set()
+    {
+        std::set<local_apic> lapic_set;
+        acpi_ptr p = ics;
+        acpi_ptr end = ics + (header.length - 44);
+
+        while (p < end) {
+            ics_header h = ics_header(p);
+            if (h.type == LAPIC) {
+                local_apic l = local_apic(p);
+                lapic_set.insert(l);
+            }
+
+            p += h.length;
+        }
+
+        return lapic_set;
+    }
+
+    std::set<io_apic> get_ioapic_set()
+    {
+        std::set<io_apic> ioapic_set;
+        acpi_ptr p = ics;
+        acpi_ptr end = ics + (header.length - 44);
+
+        while (p < end) {
+            ics_header h = ics_header(p);
+            if (h.type == IOAPIC) {
+                io_apic io = io_apic(p);
+                ioapic_set.insert(io);
+            }
+
+            p += h.length;
+        }
+
+        return ioapic_set;
+    }
+};
+
+struct rsdt {
+    acpi_ptr base = NULL;
+    acpi_header header;
+    uint32_t * entries = NULL;
+
+    rsdt() = default;
+    rsdt(acpi_ptr b)
+    {
+        base = b;
+        header = acpi_header(base);
+        entries = reinterpret_cast<uint32_t*>(base + 36);
+    }
+
+    madt get_madt()
+    {
+        uint32_t num_entries = (header.length - 36) / 4;
+        for (uint32_t i = 0; i < num_entries; i++) {
+            acpi_ptr p = reinterpret_cast<acpi_ptr>(entries[i]);
+            char signature[5] = { ' ', ' ', ' ', ' ', '\0' };
+            memcpy(signature, p, 4);
+            if (strcmp(signature, "APIC") == 0) {
+                return madt(p);
+            }
+        }
+
+        bferror_info(0, "Unable to find Multiple APIC Description Table");
+        // Return default empty MADT if not found.
+        // Should never get this far due to error thrown above
+        return nullptr;
+    }
+};
+
+struct xsdt {
+    acpi_ptr base = NULL;
+    acpi_header header;
+    uint64_t * entries = NULL;
+
+    xsdt() = default;
+    xsdt(acpi_ptr b)
+    {
+        base = b;
+        header = acpi_header(base);
+        entries = reinterpret_cast<uint64_t*>(base + 36);
+    }
+
+    madt get_madt()
+    {
+        uint32_t num_entries = (header.length - 36) / 8;
+        for (uint32_t i = 0; i < num_entries; i++) {
+            acpi_ptr p = reinterpret_cast<acpi_ptr>(entries[i]);
+            char signature[5] = { ' ', ' ', ' ', ' ', '\0' };
+            memcpy(signature, p, 4);
+            if (strcmp(signature, "APIC") == 0) {
+                return madt(p);
+            }
+        }
+
+        bferror_info(0, "Unable to find Multiple APIC Description Table");
+        // Return default empty MADT if not found.
+        // Should never get this far due to error thrown above
+        return nullptr;
+    }
+};
+
+struct rsdp {
+    acpi_ptr base = NULL;
+    char signature[9] = { ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '\0' };
+    uint8_t checksum = 1;
+    char oem_id[7] = { ' ', ' ', ' ', ' ', ' ', ' ', '\0' };
+    uint8_t revision = 0;
+    uint32_t rsdt_address = 0;
+    uint32_t length = 0;
+    uint64_t xsdt_address = 0;
+    uint8_t ext_checksum = 1;
+
+    rsdp() = default;
+    rsdp(acpi_ptr b)
+    {
+        base = b;
+        memcpy(signature, base, 8);
+        memcpy(&checksum, base + 8, 1);
+        memcpy(oem_id, base + 9, 6);
+        memcpy(&revision, base + 15, 1);
+        rsdt_address = ::acpi::read_uint32(base + 16);
+        length = ::acpi::read_uint32(base + 20);
+        xsdt_address = ::acpi::read_uint64(base + 24);
+        memcpy(&ext_checksum, base + 32, 1);
+    }
+
+    madt get_madt()
+    {
+        // Use XSDT if available
+        if (revision >= 2) {
+            xsdt system_table = xsdt(reinterpret_cast<acpi_ptr>(xsdt_address));
+            return system_table.get_madt();
+        }
+
+        // Use RSDT if XSDT is not available
+        rsdt system_table = rsdt(reinterpret_cast<acpi_ptr>(rsdt_address));
+        return system_table.get_madt();
+    }
+};
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/tests/acpi/CMakeLists.txt
+++ b/tests/acpi/CMakeLists.txt
@@ -1,4 +1,3 @@
-#
 # Bareflank Hypervisor
 # Copyright (C) 2018 Assured Information Security, Inc.
 #
@@ -16,16 +15,10 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-cmake_minimum_required(VERSION 3.6)
-project(eapis_test C CXX)
-
-include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project(
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
+list(APPEND ARGN
 )
 
-add_subdirectory(../src/hve ${CMAKE_CURRENT_BINARY_DIR}/src/hve)
-
-add_subdirectory(acpi)
-add_subdirectory(hve)
-add_subdirectory(util)
+do_test(test_acpi
+    SOURCES test_acpi.cpp
+    ${ARGN}
+)

--- a/tests/acpi/test_acpi.cpp
+++ b/tests/acpi/test_acpi.cpp
@@ -1,0 +1,358 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.  //
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <catch/catch.hpp>
+#include <intrinsics.h>
+
+namespace acpi = eapis::acpi;
+
+uint8_t g_rsdp[36] = {
+    'R', 'S', 'D', ' ', 'P', 'T', 'R', ' ',     // Signature
+    0,                                          // Checksum
+    'O', 'E', 'M', ' ', 'I', 'D',               // OEM ID
+    2,                                          // Revision
+    0, 0, 0, 0,                                 // RSDT Address (Not a real address)
+    36, 0, 0, 0,                                // Length
+    0, 0, 0, 0,                                 // XSDT Address (Not a real address)
+    0,                                          // Extended Checksum
+    0, 0, 0                                     // Reserved
+};
+
+uint8_t g_xsdt[52] = {
+    'X', 'S', 'D', 'T',                         // Signature
+    52, 0, 0, 0,                                // Length
+    1,                                          // Revision
+    0,                                          // Checksum
+    'O', 'E', 'M', ' ', 'I', 'D',               // OEM ID
+    'O', 'E', 'M', ' ', 'X', 'S', 'D', 'T',     // OEM Table ID
+    1, 0, 0, 0,                                 // OEM Revision
+    'T', 'E', 'S', 'T',                         // Creator ID
+    1, 0, 0, 0,                                 // Creator Revision
+    1, 0, 0, 0, 0, 0, 0, 0,                     // Entry 1 (Not a real address)
+    2, 0, 0, 0, 0, 0, 0, 0                      // Entry 2 (Not a real address)
+};
+
+uint8_t g_rsdt[44] = {
+    'R', 'S', 'D', 'T',                         // Signature
+    44, 0, 0, 0,                                // Length
+    1,                                          // Revision
+    0,                                          // Checksum
+    'O', 'E', 'M', ' ', 'I', 'D',               // OEM ID
+    'O', 'E', 'M', ' ', 'R', 'S', 'D', 'T',     // OEM Table ID
+    1, 0, 0, 0,                                 // OEM Revision
+    'T', 'E', 'S', 'T',                         // Creator ID
+    1, 0, 0, 0,                                 // Creator Revision
+    1, 0, 0, 0,                                 // Entry 1 (Not a real address)
+    2, 0, 0, 0                                  // Entry 2 (Not a real address)
+};
+
+uint8_t g_madt[84] = {
+    'A', 'P', 'I', 'C',                         // Signature
+    84, 0, 0, 0,                                // Length
+    4,                                          // Revision
+    0,                                          // Checksum
+    'O', 'E', 'M', ' ', 'I', 'D',               // OEM ID
+    'O', 'E', 'M', ' ', 'M', 'A', 'D', 'T',     // OEM Table ID
+    1, 0, 0, 0,                                 // OEM Revision
+    'T', 'E', 'S', 'T',                         // Creator ID
+    1, 0, 0, 0,                                 // Creator Revision
+    1, 0, 0, 0,                                 // Local Interrupt Address
+    1, 0, 0, 0,                                 // Flags
+    // Local APIC 1
+    0,                                          // Type
+    8,                                          // Length
+    1,                                          // ACPI UID
+    1,                                          // APIC ID
+    1, 0, 0, 0,                                 // Flags
+    // Local APIC 2
+    0,                                          // Type
+    8,                                          // Length
+    2,                                          // ACPI UID
+    2,                                          // APIC ID
+    1, 0, 0, 0,                                 // Flags
+    // IO APIC 1
+    1,                                          // Type
+    12,                                         // Length
+    1,                                          // IO APIC ID
+    0,                                          // Reserved
+    1, 0, 0, 0,                                 // IO APIC Address
+    1, 0, 0, 0,                                 // Global System Interrupt Base
+    // IO Apic 2
+    1,                                          // Type
+    12,                                         // Length
+    2,                                          // IO APIC ID
+    0,                                          // Reserved
+    2, 0, 0, 0,                                 // IO APIC Address
+    1, 0, 0, 0                                  // Global System Interrupt Base
+};
+
+uint8_t g_lapic[8] = {
+    0,                                          // Type
+    8,                                          // Length
+    1,                                          // ACPI UID
+    1,                                          // APIC ID
+    1, 0, 0, 0                                  // Flags
+};
+
+uint8_t g_ioapic[12] = {
+    1,                                          // Type
+    12,                                         // Length
+    1,                                          // IO APIC ID
+    0,                                          // Reserved
+    1, 0, 0, 0,                                 // IO APIC Address
+    1, 0, 0, 0                                  // Global System Interrupt Base
+};
+
+TEST_CASE("test name goes here")
+{
+    CHECK(true);
+}
+
+TEST_CASE("acpi_header: constructor")
+{
+    acpi::acpi_header h = acpi::acpi_header(g_xsdt);
+
+    CHECK(strcmp(h.signature, "XSDT") == 0);
+    CHECK(h.length == 52);
+    CHECK(h.revision == 1);
+    CHECK(h.checksum == 0);
+    CHECK(strcmp(h.oem_id, "OEM ID") == 0);
+    CHECK(strcmp(h.oem_table_id, "OEM XSDT") == 0);
+    CHECK(h.oem_revision == 1);
+    CHECK(strcmp(h.creator_id, "TEST") == 0);
+    CHECK(h.creator_revision == 1);
+}
+
+TEST_CASE("ics_header: constructor")
+{
+    acpi::ics_header h = acpi::ics_header(g_lapic);
+
+    CHECK(h.type == 0);
+    CHECK(h.length == 8);
+}
+
+TEST_CASE("local_apic: constructor")
+{
+    acpi::local_apic l = acpi::local_apic(g_lapic);
+
+    CHECK(l.base == g_lapic);
+    CHECK(l.header.type == 0);
+    CHECK(l.header.length == 8);
+    CHECK(l.acpi_uid == 1);
+    CHECK(l.apic_id == 1);
+    CHECK(l.flags == 1);
+}
+
+TEST_CASE("local_apic: is_enabled")
+{
+    acpi::local_apic l = acpi::local_apic(g_lapic);
+    l.flags = 1;
+
+    CHECK(l.is_enabled());
+
+    l.flags = 0;
+    CHECK_FALSE(l.is_enabled());
+}
+
+TEST_CASE("io_apic: constructor")
+{
+    acpi::io_apic io = acpi::io_apic(g_ioapic);
+
+    CHECK(io.base == g_ioapic);
+    CHECK(io.header.type == 1);
+    CHECK(io.header.length == 12);
+    CHECK(io.io_apic_address == 1);
+    CHECK(io.global_interrupt_base == 1);
+}
+
+TEST_CASE("madt: constructor")
+{
+    acpi::madt m = acpi::madt(g_madt);
+
+    CHECK(m.base == g_madt);
+    CHECK(strcmp(m.header.signature, "APIC") == 0);
+    CHECK(m.header.length == 84);
+    CHECK(m.header.revision == 4);
+    CHECK(m.header.checksum == 0);
+    CHECK(strcmp(m.header.oem_id, "OEM ID") == 0);
+    CHECK(strcmp(m.header.oem_table_id, "OEM MADT") == 0);
+    CHECK(m.header.oem_revision == 1);
+    CHECK(strcmp(m.header.creator_id, "TEST") == 0);
+    CHECK(m.header.creator_revision == 1);
+    CHECK(m.ics == g_madt + 44);
+}
+
+TEST_CASE("madt: is_pcat_compatible")
+{
+    acpi::madt m = acpi::madt(g_madt);
+
+    m.flags = 1;
+    CHECK(m.is_pcat_compatible());
+
+    m.flags = 0;
+    CHECK_FALSE(m.is_pcat_compatible());
+}
+
+TEST_CASE("madt: get_local_apic_set")
+{
+    acpi::madt m = acpi::madt(g_madt);
+    std::set<acpi::local_apic> lapic_set = m.get_lapic_set();
+
+    CHECK(lapic_set.size() == 2);
+
+    auto iter = lapic_set.begin();
+    CHECK(iter->apic_id == 1);
+
+    iter++;
+    CHECK(iter->apic_id == 2);
+}
+
+TEST_CASE("madt: get_io_apic_set")
+{
+    acpi::madt m = acpi::madt(g_madt);
+    std::set<acpi::io_apic> ioapic_set = m.get_ioapic_set();
+
+    CHECK(ioapic_set.size() == 2);
+
+    auto iter = ioapic_set.begin();
+    CHECK(iter->io_apic_id == 1);
+
+    iter++;
+    CHECK(iter->io_apic_id == 2);
+}
+
+TEST_CASE("rsdt: constructor")
+{
+    acpi::rsdt systable = acpi::rsdt(g_rsdt);
+
+    CHECK(systable.base == g_rsdt);
+    CHECK(strcmp(systable.header.signature, "RSDT") == 0);
+    CHECK(systable.header.length == 44);
+    CHECK(systable.header.revision == 1);
+    CHECK(systable.header.checksum == 0);
+    CHECK(strcmp(systable.header.oem_id, "OEM ID") == 0);
+    CHECK(strcmp(systable.header.oem_table_id, "OEM RSDT") == 0);
+    CHECK(systable.header.oem_revision == 1);
+    CHECK(strcmp(systable.header.creator_id, "TEST") == 0);
+    CHECK(systable.header.creator_revision == 1);
+    CHECK(systable.entries[0] == 1);
+    CHECK(systable.entries[1] == 2);
+}
+
+//// TODO RSDT get_madt
+//// Currently doesn't work because 64bit addresses don't fit in the 32bit
+//// slots on the RSDT
+//TEST_CASE("rsdt: get_madt")
+//{
+//    CHECK(true);
+//    acpi::rsdt systab = acpi::rsdt(g_rsdt);
+//    systab.entries[0] = reinterpret_cast<uintptr_t>(g_madt);
+//    acpi::madt m = systab.get_madt();
+//
+//    CHECK(m.base == g_madt);
+//    CHECK(strcmp(m.header.signature, "APIC") == 0);
+//    CHECK(m.header.length == 84);
+//    CHECK(m.header.revision == 4);
+//    CHECK(m.header.checksum == 0);
+//    CHECK(strcmp(m.header.oem_id, "OEM ID") == 0);
+//    CHECK(strcmp(m.header.oem_table_id, "OEM MADT") == 0);
+//    CHECK(m.header.oem_revision == 1);
+//    CHECK(strcmp(m.header.creator_id, "TEST") == 0);
+//    CHECK(m.header.creator_revision == 1);
+//    CHECK(m.ics == g_madt + 44);
+//}
+
+TEST_CASE("xsdt: constructor")
+{
+    acpi::xsdt systable = acpi::xsdt(g_xsdt);
+
+    CHECK(systable.base == g_xsdt);
+    CHECK(strcmp(systable.header.signature, "XSDT") == 0);
+    CHECK(systable.header.length == 52);
+    CHECK(systable.header.revision == 1);
+    CHECK(systable.header.checksum == 0);
+    CHECK(strcmp(systable.header.oem_id, "OEM ID") == 0);
+    CHECK(strcmp(systable.header.oem_table_id, "OEM XSDT") == 0);
+    CHECK(systable.header.oem_revision == 1);
+    CHECK(strcmp(systable.header.creator_id, "TEST") == 0);
+    CHECK(systable.header.creator_revision == 1);
+    CHECK(systable.entries[0] == 1);
+    CHECK(systable.entries[1] == 2);
+}
+
+TEST_CASE("xsdt: get_madt")
+{
+    acpi::xsdt systab = acpi::xsdt(g_xsdt);
+    systab.entries[0] = reinterpret_cast<uintptr_t>(g_madt);
+    acpi::madt m = systab.get_madt();
+
+    CHECK(m.base == g_madt);
+    CHECK(strcmp(m.header.signature, "APIC") == 0);
+    CHECK(m.header.length == 84);
+    CHECK(m.header.revision == 4);
+    CHECK(m.header.checksum == 0);
+    CHECK(strcmp(m.header.oem_id, "OEM ID") == 0);
+    CHECK(strcmp(m.header.oem_table_id, "OEM MADT") == 0);
+    CHECK(m.header.oem_revision == 1);
+    CHECK(strcmp(m.header.creator_id, "TEST") == 0);
+    CHECK(m.header.creator_revision == 1);
+    CHECK(m.ics == g_madt + 44);
+}
+
+TEST_CASE("rsdp: constructor")
+{
+    acpi::rsdp root = acpi::rsdp(g_rsdp);
+
+    CHECK(root.base == g_rsdp);
+    CHECK(strcmp(root.signature, "RSD PTR ") == 0);
+    CHECK(root.checksum == 0);
+    CHECK(strcmp(root.oem_id, "OEM ID") == 0);
+    CHECK(root.revision == 2);
+    CHECK(root.rsdt_address == 0);
+    CHECK(root.length == 36);
+    CHECK(root.xsdt_address == 0);
+    CHECK(root.ext_checksum == 0);
+}
+
+TEST_CASE("rsdp: get_madt")
+{
+    acpi::rsdp root = acpi::rsdp(g_rsdp);
+    acpi::xsdt systab = acpi::xsdt(g_xsdt);
+    systab.entries[0] = reinterpret_cast<uintptr_t>(g_madt);
+    root.xsdt_address = reinterpret_cast<uintptr_t>(systab.base);
+    root.revision = 2;
+
+    acpi::madt m = root.get_madt();
+    CHECK(m.base == g_madt);
+    CHECK(strcmp(m.header.signature, "APIC") == 0);
+    CHECK(m.header.length == 84);
+    CHECK(m.header.revision == 4);
+    CHECK(m.header.checksum == 0);
+    CHECK(strcmp(m.header.oem_id, "OEM ID") == 0);
+    CHECK(strcmp(m.header.oem_table_id, "OEM MADT") == 0);
+    CHECK(m.header.oem_revision == 1);
+    CHECK(strcmp(m.header.creator_id, "TEST") == 0);
+    CHECK(m.header.creator_revision == 1);
+    CHECK(m.ics == g_madt + 44);
+
+    //// TODO Revision < 2
+    //// Currently doesn't work because 64bit addresses don't fit in the 32bit
+    //// slots on the RSDT
+    //root.revision = 1;
+    //root.rsdt_address = reinterpret_cast<uintptr_t>(g_rsdp);
+    //m = root.get_madt();
+}


### PR DESCRIPTION
Took the struct implementation of the ACPI tables from the hypervisor repo and implemented them in the Extended APIs repo. Now, users who include EAPIs are able to store the ACPI tables in data structures, and hypervisor users just access the data from memory.